### PR TITLE
Add limit clause to Break string

### DIFF
--- a/demo/CarbunqlWeb/Pages/Index.razor
+++ b/demo/CarbunqlWeb/Pages/Index.razor
@@ -82,18 +82,25 @@ order by
 
 <div class="container-fluid">
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-5">
             <RadzenText TextStyle="TextStyle.H5">Input SQL</RadzenText>
             <RadzenTextArea @bind-Value=@sql TValue="string" Change=@OnChange Style="width: 100%; min-height: 600px; font-family: 'Ricty Diminished', SFMono-Regular, Consolas, 'Courier New', 'BIZ UDGothic', Meiryo, monospace; font-size: 18px; white-space: nowrap;" />
         </div>
-        <div class="col-md-6">
-            <RadzenText TextStyle="TextStyle.H5">Analysis result</RadzenText>
+        <div class="col-md-2">
+            <RadzenText TextStyle="TextStyle.H5">Tokens</RadzenText>
+            <RadzenListBox @bind-Value=@selectToken Data=@tokens TextProperty="Text" ValueProperty="Text" Style="width: 100%; height: 600px; margin : 0px"/>
+        </div>
+        <div class="col-md-5">
+            <RadzenText TextStyle="TextStyle.H5">Format SQL</RadzenText>
             <RadzenTextArea @bind-Value=@fsql TValue="string" Change=@OnChange Style="width: 100%; min-height: 600px; font-family: 'Ricty Diminished', SFMono-Regular, Consolas, 'Courier New', 'BIZ UDGothic', Meiryo, monospace; font-size: 18px;" ReadOnly="true" />
         </div>
     </div>
 </div>
 
 @code {
+    IEnumerable<Token>? tokens = null;
+    object? selectToken = null;
+
     protected override void OnInitialized()
     {
         OnChange(sql);
@@ -107,11 +114,11 @@ order by
         {
             var bld = new CommandTextBuilder();
             var sq = QueryParser.Parse(sql);
-            fsql = bld.Execute(sq);
+            tokens = sq.GetTokens(null).ToList();
+            fsql = bld.Execute(tokens);
         }
         catch (Exception ex)
-        {
-            
+        {            
             fsql = ex.ToString();
         }
 

--- a/src/Carbunql.Analysis/TokenReader.cs
+++ b/src/Carbunql.Analysis/TokenReader.cs
@@ -5,279 +5,280 @@ namespace Carbunql.Analysis;
 
 public class TokenReader : LexReader
 {
-	public TokenReader(string text) : base(text)
-	{
-	}
+    public TokenReader(string text) : base(text)
+    {
+    }
 
-	public static string?[] BreakTokens = new string?[]
-	{
-		null,
-		string.Empty,
-		",",
-		"with",
-		"values",
-		"select",
-		"from",
-		"where",
-		"group",
-		"having",
-		"order",
-		"union",
-		"minus",
-		"except",
-		"intersect"
-	};
+    public static string?[] BreakTokens = new string?[]
+    {
+        null,
+        string.Empty,
+        ",",
+        "with",
+        "values",
+        "select",
+        "from",
+        "where",
+        "group",
+        "having",
+        "order",
+        "union",
+        "minus",
+        "except",
+        "intersect",
+        "limit"
+    };
 
-	private string? TokenCache { get; set; } = string.Empty;
+    private string? TokenCache { get; set; } = string.Empty;
 
-	public string? PeekRawToken(bool skipComment = true)
-	{
-		if (string.IsNullOrEmpty(TokenCache))
-		{
-			TokenCache = ReadRawToken(skipSpace: true);
-		}
+    public string? PeekRawToken(bool skipComment = true)
+    {
+        if (string.IsNullOrEmpty(TokenCache))
+        {
+            TokenCache = ReadRawToken(skipSpace: true);
+        }
 
-		if (!skipComment || string.IsNullOrEmpty(TokenCache)) return TokenCache;
+        if (!skipComment || string.IsNullOrEmpty(TokenCache)) return TokenCache;
 
-		var tokens = new string[] { "--", "/*" };
-		while (TokenCache.AreContains(tokens))
-		{
-			var t = ReadToken(skipComment: false);
-			if (t == "--")
-			{
-				ReadUntilLineEnd();
-			}
-			else
-			{
-				ReadUntilCloseBlockComment();
-			}
-			TokenCache = ReadRawToken(skipSpace: true);
-		}
-		return TokenCache;
-	}
+        var tokens = new string[] { "--", "/*" };
+        while (TokenCache.AreContains(tokens))
+        {
+            var t = ReadToken(skipComment: false);
+            if (t == "--")
+            {
+                ReadUntilLineEnd();
+            }
+            else
+            {
+                ReadUntilCloseBlockComment();
+            }
+            TokenCache = ReadRawToken(skipSpace: true);
+        }
+        return TokenCache;
+    }
 
-	public string? TryReadToken(string expectRawToken)
-	{
-		var s = PeekRawToken();
-		if (!s.AreEqual(expectRawToken)) return null;
-		return ReadToken();
-	}
+    public string? TryReadToken(string expectRawToken)
+    {
+        var s = PeekRawToken();
+        if (!s.AreEqual(expectRawToken)) return null;
+        return ReadToken();
+    }
 
-	public string ReadToken(string expectRawToken)
-	{
-		var s = PeekRawToken();
-		if (string.IsNullOrEmpty(s)) throw new SyntaxException($"expect '{expectRawToken}', actual is empty.");
-		if (!s.AreEqual(expectRawToken)) throw new SyntaxException($"expect '{expectRawToken}', actual '{s}'.");
-		return ReadToken();
-	}
+    public string ReadToken(string expectRawToken)
+    {
+        var s = PeekRawToken();
+        if (string.IsNullOrEmpty(s)) throw new SyntaxException($"expect '{expectRawToken}', actual is empty.");
+        if (!s.AreEqual(expectRawToken)) throw new SyntaxException($"expect '{expectRawToken}', actual '{s}'.");
+        return ReadToken();
+    }
 
-	public string ReadToken(string[] expectRawTokens)
-	{
-		var s = PeekRawToken();
-		if (string.IsNullOrEmpty(s)) throw new SyntaxException($"token is empty.");
-		if (!s.AreContains(expectRawTokens)) throw new SyntaxException($"near '{s}'.");
-		return ReadToken();
-	}
+    public string ReadToken(string[] expectRawTokens)
+    {
+        var s = PeekRawToken();
+        if (string.IsNullOrEmpty(s)) throw new SyntaxException($"token is empty.");
+        if (!s.AreContains(expectRawTokens)) throw new SyntaxException($"near '{s}'.");
+        return ReadToken();
+    }
 
-	public string ReadToken(bool skipComment = true)
-	{
-		string? token = ReadRawToken();
-		if (string.IsNullOrEmpty(token)) return string.Empty;
+    public string ReadToken(bool skipComment = true)
+    {
+        string? token = ReadRawToken();
+        if (string.IsNullOrEmpty(token)) return string.Empty;
 
-		// Explore possible two-word tokens
-		if (token.AreEqual("is"))
-		{
-			if (PeekRawToken().AreEqual("not"))
-			{
-				return token + " " + ReadToken("not");
-			}
-			return token;
-		}
+        // Explore possible two-word tokens
+        if (token.AreEqual("is"))
+        {
+            if (PeekRawToken().AreEqual("not"))
+            {
+                return token + " " + ReadToken("not");
+            }
+            return token;
+        }
 
-		if (token.AreContains(new string[] { "inner", "cross" }))
-		{
-			var outer = TryReadToken("outer");
-			if (!string.IsNullOrEmpty(outer)) token += " " + outer;
-			var t = ReadToken("join");
-			return token + " " + t;
-		}
+        if (token.AreContains(new string[] { "inner", "cross" }))
+        {
+            var outer = TryReadToken("outer");
+            if (!string.IsNullOrEmpty(outer)) token += " " + outer;
+            var t = ReadToken("join");
+            return token + " " + t;
+        }
 
-		if (token.AreContains(new string[] { "group", "partition", "order" }))
-		{
-			var t = ReadToken("by");
-			return token + " " + t;
-		}
+        if (token.AreContains(new string[] { "group", "partition", "order" }))
+        {
+            var t = ReadToken("by");
+            return token + " " + t;
+        }
 
-		if (token.AreContains(new string[] { "left", "right" }))
-		{
-			if (PeekRawToken().AreEqual("(")) return token;
-			var outer = TryReadToken("outer");
-			if (!string.IsNullOrEmpty(outer)) token += " " + outer;
-			var t = ReadToken("join");
-			return token + " " + t;
-		}
+        if (token.AreContains(new string[] { "left", "right" }))
+        {
+            if (PeekRawToken().AreEqual("(")) return token;
+            var outer = TryReadToken("outer");
+            if (!string.IsNullOrEmpty(outer)) token += " " + outer;
+            var t = ReadToken("join");
+            return token + " " + t;
+        }
 
-		if (token.AreEqual("nulls"))
-		{
-			var t = ReadToken(new string[] { "first", "last" });
-			return token + " " + t;
-		}
+        if (token.AreEqual("nulls"))
+        {
+            var t = ReadToken(new string[] { "first", "last" });
+            return token + " " + t;
+        }
 
-		if (token.AreEqual("union"))
-		{
-			if (PeekRawToken().AreEqual("all"))
-			{
-				return token + " " + ReadToken("all");
-			}
-			return token;
-		}
+        if (token.AreEqual("union"))
+        {
+            if (PeekRawToken().AreEqual("all"))
+            {
+                return token + " " + ReadToken("all");
+            }
+            return token;
+        }
 
-		if (token.AreEqual("not"))
-		{
-			if (PeekRawToken().AreEqual("materialized"))
-			{
-				return token + " " + ReadToken("materialized");
-			}
-			return token;
-		}
+        if (token.AreEqual("not"))
+        {
+            if (PeekRawToken().AreEqual("materialized"))
+            {
+                return token + " " + ReadToken("materialized");
+            }
+            return token;
+        }
 
-		if (token.AreEqual(":"))
-		{
-			//ex ::text
-			return token + ReadToken();
-		}
+        if (token.AreEqual(":"))
+        {
+            //ex ::text
+            return token + ReadToken();
+        }
 
-		if (!skipComment) return token;
+        if (!skipComment) return token;
 
-		if (token == "--")
-		{
-			ReadUntilLineEnd();
-			return ReadToken(skipComment);
-		}
+        if (token == "--")
+        {
+            ReadUntilLineEnd();
+            return ReadToken(skipComment);
+        }
 
-		if (token == "/*")
-		{
-			ReadUntilCloseBlockComment();
-			return ReadToken(skipComment);
-		}
-		return token;
-	}
+        if (token == "/*")
+        {
+            ReadUntilCloseBlockComment();
+            return ReadToken(skipComment);
+        }
+        return token;
+    }
 
-	private string? ReadRawToken(bool skipSpace = true)
-	{
-		if (!string.IsNullOrEmpty(TokenCache))
-		{
-			var s = TokenCache;
-			TokenCache = string.Empty;
-			return s;
-		}
-		return ReadLexs(skipSpace).FirstOrDefault();
-	}
+    private string? ReadRawToken(bool skipSpace = true)
+    {
+        if (!string.IsNullOrEmpty(TokenCache))
+        {
+            var s = TokenCache;
+            TokenCache = string.Empty;
+            return s;
+        }
+        return ReadLexs(skipSpace).FirstOrDefault();
+    }
 
-	private IEnumerable<string> ReadRawTokens(bool skipSpace = true)
-	{
-		var token = ReadRawToken(skipSpace: skipSpace);
-		while (!string.IsNullOrEmpty(token))
-		{
-			yield return token;
-			token = ReadRawToken(skipSpace: skipSpace);
-		}
-	}
+    private IEnumerable<string> ReadRawTokens(bool skipSpace = true)
+    {
+        var token = ReadRawToken(skipSpace: skipSpace);
+        while (!string.IsNullOrEmpty(token))
+        {
+            yield return token;
+            token = ReadRawToken(skipSpace: skipSpace);
+        }
+    }
 
-	internal (string first, string inner) ReadUntilCloseBracket()
-	{
-		SkipSpace();
-		using var sb = ZString.CreateStringBuilder();
-		var fs = string.Empty;
+    internal (string first, string inner) ReadUntilCloseBracket()
+    {
+        SkipSpace();
+        using var sb = ZString.CreateStringBuilder();
+        var fs = string.Empty;
 
-		foreach (var word in ReadRawTokens(skipSpace: false))
-		{
-			if (word == null) break;
-			if (string.IsNullOrEmpty(fs)) fs = word;
+        foreach (var word in ReadRawTokens(skipSpace: false))
+        {
+            if (word == null) break;
+            if (string.IsNullOrEmpty(fs)) fs = word;
 
-			if (word.AreEqual(")"))
-			{
-				return (fs, sb.ToString());
-			}
+            if (word.AreEqual(")"))
+            {
+                return (fs, sb.ToString());
+            }
 
-			if (word.AreEqual("("))
-			{
-				var (_, inner) = ReadUntilCloseBracket();
-				sb.Append("(" + inner + ")");
-			}
-			else
-			{
-				sb.Append(word);
-			}
-		}
+            if (word.AreEqual("("))
+            {
+                var (_, inner) = ReadUntilCloseBracket();
+                sb.Append("(" + inner + ")");
+            }
+            else
+            {
+                sb.Append(word);
+            }
+        }
 
-		throw new SyntaxException("bracket is not closed");
-	}
+        throw new SyntaxException("bracket is not closed");
+    }
 
-	private string ReadUntilCloseBlockComment()
-	{
-		using var inner = ZString.CreateStringBuilder();
+    private string ReadUntilCloseBlockComment()
+    {
+        using var inner = ZString.CreateStringBuilder();
 
-		foreach (var word in ReadRawTokens(skipSpace: false))
-		{
-			if (word == null) break;
+        foreach (var word in ReadRawTokens(skipSpace: false))
+        {
+            if (word == null) break;
 
-			inner.Append(word);
-			if (word.AreEqual("*/"))
-			{
-				return inner.ToString();
-			}
-			if (word.AreEqual("/*"))
-			{
-				inner.Append(ReadUntilCloseBlockComment());
-			}
-		}
+            inner.Append(word);
+            if (word.AreEqual("*/"))
+            {
+                return inner.ToString();
+            }
+            if (word.AreEqual("/*"))
+            {
+                inner.Append(ReadUntilCloseBlockComment());
+            }
+        }
 
-		throw new SyntaxException("block comment is not closed");
-	}
+        throw new SyntaxException("block comment is not closed");
+    }
 
-	internal string ReadUntilCaseExpressionEnd()
-	{
-		using var inner = ZString.CreateStringBuilder();
+    internal string ReadUntilCaseExpressionEnd()
+    {
+        using var inner = ZString.CreateStringBuilder();
 
-		foreach (var word in ReadRawTokens(skipSpace: false))
-		{
-			if (word == null) break;
+        foreach (var word in ReadRawTokens(skipSpace: false))
+        {
+            if (word == null) break;
 
-			inner.Append(word);
-			if (word.TrimStart().AreEqual("end"))
-			{
-				return inner.ToString();
-			}
-			if (word.TrimStart().AreEqual("case"))
-			{
-				inner.Append(ReadUntilCaseExpressionEnd());
-			}
-		}
+            inner.Append(word);
+            if (word.TrimStart().AreEqual("end"))
+            {
+                return inner.ToString();
+            }
+            if (word.TrimStart().AreEqual("case"))
+            {
+                inner.Append(ReadUntilCaseExpressionEnd());
+            }
+        }
 
-		throw new SyntaxException("case expression is not end");
-	}
+        throw new SyntaxException("case expression is not end");
+    }
 
-	internal string ReadUntilToken(string breaktoken)
-	{
-		return ReadUntilToken(x => x.AreEqual(breaktoken));
-	}
+    internal string ReadUntilToken(string breaktoken)
+    {
+        return ReadUntilToken(x => x.AreEqual(breaktoken));
+    }
 
-	internal string ReadUntilToken(Func<string, bool> fn)
-	{
-		using var inner = ZString.CreateStringBuilder();
+    internal string ReadUntilToken(Func<string, bool> fn)
+    {
+        using var inner = ZString.CreateStringBuilder();
 
-		SkipSpace();
-		foreach (var word in ReadRawTokens(skipSpace: false))
-		{
-			if (word == null) break;
-			if (fn(word.TrimStart()))
-			{
-				return inner.ToString();
-			}
-			inner.Append(word);
-		}
+        SkipSpace();
+        foreach (var word in ReadRawTokens(skipSpace: false))
+        {
+            if (word == null) break;
+            if (fn(word.TrimStart()))
+            {
+                return inner.ToString();
+            }
+            inner.Append(word);
+        }
 
-		throw new SyntaxException($"breaktoken token is not found");
-	}
+        throw new SyntaxException($"breaktoken token is not found");
+    }
 }

--- a/src/Carbunql/QueryBase.cs
+++ b/src/Carbunql/QueryBase.cs
@@ -5,45 +5,45 @@ namespace Carbunql;
 
 public abstract class QueryBase : IQueryCommandable
 {
-	public WithClause? WithClause { get; set; }
+    public WithClause? WithClause { get; set; }
 
-	public OperatableQuery? OperatableQuery { get; private set; }
+    public OperatableQuery? OperatableQuery { get; private set; }
 
-	public OrderClause? OrderClause { get; set; }
+    public OrderClause? OrderClause { get; set; }
 
-	public LimitClause? LimitClause { get; set; }
+    public LimitClause? LimitClause { get; set; }
 
-	public QueryBase AddOperatableValue(string @operator, QueryBase query)
-	{
-		if (OperatableQuery != null) throw new InvalidOperationException();
-		OperatableQuery = new OperatableQuery(@operator, query);
-		return query;
-	}
+    public QueryBase AddOperatableValue(string @operator, QueryBase query)
+    {
+        if (OperatableQuery != null) throw new InvalidOperationException();
+        OperatableQuery = new OperatableQuery(@operator, query);
+        return query;
+    }
 
-	public IDictionary<string, object?>? Parameters { get; set; }
+    public IDictionary<string, object?>? Parameters { get; set; }
 
-	public virtual IDictionary<string, object?> GetParameters()
-	{
-		var prm = EmptyParameters.Get();
-		prm = prm.Merge(Parameters);
-		prm = prm.Merge(OperatableQuery!.GetParameters());
-		return prm;
-	}
+    public virtual IDictionary<string, object?> GetParameters()
+    {
+        var prm = EmptyParameters.Get();
+        prm = prm.Merge(Parameters);
+        prm = prm.Merge(OperatableQuery!.GetParameters());
+        return prm;
+    }
 
-	public abstract IEnumerable<Token> GetCurrentTokens(Token? parent);
+    public abstract IEnumerable<Token> GetCurrentTokens(Token? parent);
 
-	public IEnumerable<Token> GetTokens(Token? parent)
-	{
-		if (WithClause != null) foreach (var item in WithClause.GetTokens(parent)) yield return item;
-		foreach (var item in GetCurrentTokens(parent)) yield return item;
-		if (OperatableQuery != null) foreach (var item in OperatableQuery.GetTokens(parent)) yield return item;
-		if (OrderClause != null) foreach (var item in OrderClause.GetTokens(parent)) yield return item;
-		if (LimitClause != null) foreach (var item in LimitClause.GetTokens(parent)) yield return item;
-	}
+    public IEnumerable<Token> GetTokens(Token? parent = null)
+    {
+        if (WithClause != null) foreach (var item in WithClause.GetTokens(parent)) yield return item;
+        foreach (var item in GetCurrentTokens(parent)) yield return item;
+        if (OperatableQuery != null) foreach (var item in OperatableQuery.GetTokens(parent)) yield return item;
+        if (OrderClause != null) foreach (var item in OrderClause.GetTokens(parent)) yield return item;
+        if (LimitClause != null) foreach (var item in LimitClause.GetTokens(parent)) yield return item;
+    }
 
-	public QueryCommand ToCommand()
-	{
-		var sql = GetTokens(null).ToText();
-		return new QueryCommand(sql, GetParameters());
-	}
+    public QueryCommand ToCommand()
+    {
+        var sql = GetTokens(null).ToText();
+        return new QueryCommand(sql, GetParameters());
+    }
 }

--- a/test/Carbunql.Analysis.Test/SelectQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/SelectQueryParserTest.cs
@@ -180,6 +180,28 @@ limit 10";
     }
 
     [Fact]
+    public void LimitSample_NoAlias()
+    {
+        var text = @"
+select
+    a.id
+from
+    table_a
+limit 10";
+
+        var item = QueryParser.Parse(text) as SelectQuery;
+        if (item == null) throw new Exception();
+        Monitor.Log(item);
+
+        var lst = item.GetTokens().ToList();
+        Assert.Equal(8, lst.Count());
+        Assert.Equal("from", lst[4].Text);
+        Assert.Equal("table_a", lst[5].Text);
+        Assert.Equal("limit", lst[6].Text);
+        Assert.Equal("10", lst[7].Text);
+    }
+
+    [Fact]
     public void LimitSample_Postgres()
     {
         var text = @"


### PR DESCRIPTION
Fixed a bug that the Limit clause that omitted the table alias was not parsed.