### PR TITLE
Enabled to omit arguments when converting delete query.

### DIFF
--- a/src/Carbunql/Values/ValueCollection.cs
+++ b/src/Carbunql/Values/ValueCollection.cs
@@ -2,6 +2,7 @@
 using Carbunql.Clauses;
 using Carbunql.Extensions;
 using System.Collections;
+using System.Security.Cryptography;
 
 namespace Carbunql.Values;
 
@@ -24,6 +25,15 @@ public class ValueCollection : ValueBase, IList<ValueBase>, IQueryCommand
 	public ValueCollection(List<ValueBase> collection)
 	{
 		Collection.AddRange(collection);
+	}
+
+	public ValueCollection(string tableAlias, IEnumerable<string> columns)
+	{
+		if (!columns.Any()) throw new ArgumentException(nameof(columns));
+		foreach (var column in columns)
+		{
+			Collection.Add(new ColumnValue(tableAlias, column));
+		}
 	}
 
 	private List<ValueBase> Collection { get; init; } = new();

--- a/test/Carbunql.Building.Test/DeleteTest.cs
+++ b/test/Carbunql.Building.Test/DeleteTest.cs
@@ -40,4 +40,18 @@ public class DeleteTest
 
 		Assert.Equal(50, lst.Count());
 	}
+
+	[Fact]
+	public void DeleteQueryArgumentOmitted()
+	{
+		var sql = "select a.id, a.sub_id, a.v1, a.v2 from table as a";
+		var q = QueryParser.Parse(sql);
+
+		var uq = q.ToDeleteQuery("new_table");
+		Monitor.Log(uq);
+
+		var lst = uq.GetTokens().ToList();
+
+		Assert.Equal(45, lst.Count());
+	}
 }


### PR DESCRIPTION
If the argument is omitted, it is interpreted that the selected column is key information.