### PR TITLE
#174 CommandText generation processing was prioritized for performance.

### DIFF
--- a/src/Carbunql.Dapper/Carbunql.Dapper.csproj
+++ b/src/Carbunql.Dapper/Carbunql.Dapper.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>mk3008net</Authors>
     <Copyright>mk3008net</Copyright>
     <PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>

--- a/src/Carbunql.Dapper/Formatter.cs
+++ b/src/Carbunql.Dapper/Formatter.cs
@@ -1,0 +1,12 @@
+﻿namespace Carbunql.Dapper;
+
+public static class Formatter
+{
+	public static FormatType Type { get; set; } = FormatType.Simple;
+}
+
+public enum FormatType
+{
+	Decoration,
+	Simple
+}

--- a/src/Carbunql.Dapper/IDbConnectionExtension.cs
+++ b/src/Carbunql.Dapper/IDbConnectionExtension.cs
@@ -6,9 +6,18 @@ namespace Carbunql.Dapper;
 
 public static class IDbConnectionExtension
 {
+	private static QueryCommand GetQueryCommand(IQueryCommandable q)
+	{
+		if (Formatter.Type == FormatType.Simple)
+		{
+			return q.ToOneLineCommand();
+		}
+		return q.ToCommand();
+	}
+
 	public static int Execute(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.Execute(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.Execute(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static int Execute(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -16,7 +25,7 @@ public static class IDbConnectionExtension
 	}
 	public static object ExecuteScalar(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.ExecuteScalar(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.ExecuteScalar(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static object ExecuteScalar(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -24,7 +33,7 @@ public static class IDbConnectionExtension
 	}
 	public static T ExecuteScalar<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.ExecuteScalar<T>(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.ExecuteScalar<T>(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static T ExecuteScalar<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -32,7 +41,7 @@ public static class IDbConnectionExtension
 	}
 	public static IDataReader ExecuteReader(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.ExecuteReader(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.ExecuteReader(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static IDataReader ExecuteReader(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -40,7 +49,7 @@ public static class IDbConnectionExtension
 	}
 	public static IEnumerable<dynamic> Query(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.Query(q.ToCommand(), transaction, buffered, commandTimeout, commandType);
+		return cnn.Query(GetQueryCommand(q), transaction, buffered, commandTimeout, commandType);
 	}
 	public static IEnumerable<dynamic> Query(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -48,7 +57,7 @@ public static class IDbConnectionExtension
 	}
 	public static dynamic QueryFirst(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirst(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirst(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static dynamic QueryFirst(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -56,7 +65,7 @@ public static class IDbConnectionExtension
 	}
 	public static dynamic QueryFirstOrDefault(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirstOrDefault(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirstOrDefault(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static dynamic QueryFirstOrDefault(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -64,7 +73,7 @@ public static class IDbConnectionExtension
 	}
 	public static dynamic QuerySingle(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingle(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingle(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static dynamic QuerySingle(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -72,7 +81,7 @@ public static class IDbConnectionExtension
 	}
 	public static dynamic QuerySingleOrDefault(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingleOrDefault(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingleOrDefault(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static dynamic QuerySingleOrDefault(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -80,7 +89,7 @@ public static class IDbConnectionExtension
 	}
 	public static IEnumerable<T> Query<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.Query<T>(q.ToCommand(), transaction, buffered, commandTimeout, commandType);
+		return cnn.Query<T>(GetQueryCommand(q), transaction, buffered, commandTimeout, commandType);
 	}
 	public static IEnumerable<T> Query<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -88,7 +97,7 @@ public static class IDbConnectionExtension
 	}
 	public static T QueryFirst<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirst<T>(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirst<T>(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static T QueryFirst<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -96,7 +105,7 @@ public static class IDbConnectionExtension
 	}
 	public static T QueryFirstOrDefault<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirstOrDefault<T>(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirstOrDefault<T>(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static T QueryFirstOrDefault<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -104,7 +113,7 @@ public static class IDbConnectionExtension
 	}
 	public static T QuerySingle<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingle<T>(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingle<T>(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static T QuerySingle<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -112,7 +121,7 @@ public static class IDbConnectionExtension
 	}
 	public static T QuerySingleOrDefault<T>(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingleOrDefault<T>(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingleOrDefault<T>(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static T QuerySingleOrDefault<T>(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -120,7 +129,7 @@ public static class IDbConnectionExtension
 	}
 	public static IEnumerable<object> Query(this IDbConnection cnn, Type type, IQueryCommandable q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.Query(q.ToCommand(), transaction, buffered, commandTimeout, commandType);
+		return cnn.Query(GetQueryCommand(q), transaction, buffered, commandTimeout, commandType);
 	}
 	public static IEnumerable<object> Query(this IDbConnection cnn, Type type, QueryCommand q, IDbTransaction? transaction = null, bool buffered = true, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -128,7 +137,7 @@ public static class IDbConnectionExtension
 	}
 	public static object QueryFirst(this IDbConnection cnn, Type type, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirst(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirst(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static object QueryFirst(this IDbConnection cnn, Type type, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -136,7 +145,7 @@ public static class IDbConnectionExtension
 	}
 	public static object QueryFirstOrDefault(this IDbConnection cnn, Type type, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryFirstOrDefault(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryFirstOrDefault(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static object QueryFirstOrDefault(this IDbConnection cnn, Type type, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -144,7 +153,7 @@ public static class IDbConnectionExtension
 	}
 	public static object QuerySingle(this IDbConnection cnn, Type type, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingle(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingle(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static object QuerySingle(this IDbConnection cnn, Type type, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -152,7 +161,7 @@ public static class IDbConnectionExtension
 	}
 	public static object QuerySingleOrDefault(this IDbConnection cnn, Type type, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QuerySingleOrDefault(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QuerySingleOrDefault(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static object QuerySingleOrDefault(this IDbConnection cnn, Type type, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
@@ -160,7 +169,7 @@ public static class IDbConnectionExtension
 	}
 	public static GridReader QueryMultiple(this IDbConnection cnn, IQueryCommandable q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{
-		return cnn.QueryMultiple(q.ToCommand(), transaction, commandTimeout, commandType);
+		return cnn.QueryMultiple(GetQueryCommand(q), transaction, commandTimeout, commandType);
 	}
 	public static GridReader QueryMultiple(this IDbConnection cnn, QueryCommand q, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
 	{

--- a/test/Carbunql.Building.Test/ToTextTest.cs
+++ b/test/Carbunql.Building.Test/ToTextTest.cs
@@ -52,4 +52,100 @@ select a.column_1 as c1 from table_a as a";
 
 		Assert.Equal(TruncateControlString(sql), TruncateControlString(sq.ToOneLineText()));
 	}
+
+	[Fact]
+	public void ToOneLineText_identity()
+	{
+		var sql = @"WITH
+    dat (
+        line_id, name, unit_price, quantity, tax_rate
+    ) AS (
+        VALUES
+            (1, 'apple', 105, 5, 0.07),
+            (2, 'orange', 203, 3, 0.07),
+            (3, 'banana', 233, 9, 0.07),
+            (4, 'tea', 309, 7, 0.08),
+            (5, 'coffee', 555, 9, 0.08),
+            (6, 'cola', 456, 2, 0.08)
+    ),
+    detail AS (
+        SELECT
+            q.*,
+            TRUNC(q.price * (1 + q.tax_rate)) - q.price AS tax,
+            q.price * (1 + q.tax_rate) - q.price AS raw_tax
+        FROM
+            (
+                SELECT
+                    dat.*,
+                    (dat.unit_price * dat.quantity) AS price
+                FROM
+                    dat
+            ) AS q
+    ),
+    tax_summary AS (
+        SELECT
+            d.tax_rate,
+            TRUNC(SUM(raw_tax)) AS total_tax
+        FROM
+            detail AS d
+        GROUP BY
+            d.tax_rate
+    )
+SELECT
+    line_id,
+    name,
+    unit_price,
+    quantity,
+    tax_rate,
+    price,
+    price + tax AS tax_included_price,
+    tax
+FROM
+    (
+        SELECT
+            line_id,
+            name,
+            unit_price,
+            quantity,
+            tax_rate,
+            price,
+            tax + adjust_tax AS tax
+        FROM
+            (
+                SELECT
+                    q.*,
+                    CASE
+                        WHEN q.total_tax - q.cumulative >= q.priority THEN 1
+                        ELSE 0
+                    END AS adjust_tax
+                FROM
+                    (
+                        SELECT
+                            d.*,
+                            s.total_tax,
+                            SUM(d.tax) OVER(
+                                PARTITION BY
+                                    d.tax_rate
+                            ) AS cumulative,
+                            ROW_NUMBER() OVER(
+                                PARTITION BY
+                                    d.tax_rate
+                                ORDER BY
+                                    d.raw_tax % 1 DESC,
+                                    d.line_id
+                            ) AS priority
+                        FROM
+                            detail AS d
+                            INNER JOIN tax_summary AS s ON d.tax_rate = s.tax_rate
+                    ) AS q
+            ) AS q
+    ) AS q
+ORDER BY
+    line_id";
+		var sq = new SelectQuery(sql);
+		Output.WriteLine(sq.ToOneLineText());
+
+		var sq2 = new SelectQuery(sq.ToOneLineCommand().CommandText);
+		Assert.Equal(sql, sq2.ToCommand().CommandText);
+	}
 }


### PR DESCRIPTION
Conventionally, a formatted string was assigned, but in order to prioritize performance, the specification was changed to assign an unformatted string. 
If you want to assign a formatted string like before, specify Decoration in the Type property of the Formatter class.