### PR TITLE
#177 Supports Filter keyword

### DIFF
--- a/src/Carbunql/Analysis/Parser/FilterParser.cs
+++ b/src/Carbunql/Analysis/Parser/FilterParser.cs
@@ -1,0 +1,30 @@
+﻿using Carbunql.Values;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class FilterParser
+{
+	public static Filter Parse(string text)
+	{
+		using var r = new TokenReader(text);
+		return Parse(r);
+	}
+
+	public static Filter ParseAsInner(ITokenReader r)
+	{
+		r.Read("(");
+		using var ir = new BracketInnerTokenReader(r);
+		var v = Parse(ir);
+		return v;
+	}
+
+	public static Filter Parse(ITokenReader r)
+	{
+		r.ReadOrDefault("(");
+		r.Read("where");
+
+		var filter = new Filter() { WhereClause = WhereClauseParser.Parse(r) };
+		r.ReadOrDefault(")");
+		return filter;	
+	}
+}

--- a/src/Carbunql/Analysis/Parser/FunctionValueParser.cs
+++ b/src/Carbunql/Analysis/Parser/FunctionValueParser.cs
@@ -15,13 +15,25 @@ public static class FunctionValueParser
 	{
 		var arg = ValueCollectionParser.ParseAsInner(r);
 
-		if (!r.Peek().IsEqualNoCase("over"))
+		Filter? filter = null;
+		Over? over = null;
+
+		if (r.Peek().IsEqualNoCase("filter"))
 		{
-			return new FunctionValue(functionName, arg);
+			r.Read("filter");
+			filter = FilterParser.Parse(r);
 		}
 
-		r.Read("over");
-		var winfn = WindowFunctionParser.Parse(r);
-		return new FunctionValue(functionName, arg, winfn);
+		if (r.Peek().IsEqualNoCase("over"))
+		{
+			r.Read("over");
+			over = OverParser.Parse(r);
+		}
+
+		var fnc = new FunctionValue(functionName, arg);
+		fnc.Filter = filter;
+		fnc.Over = over;
+
+		return fnc;
 	}
 }

--- a/src/Carbunql/Analysis/Parser/OverParser.cs
+++ b/src/Carbunql/Analysis/Parser/OverParser.cs
@@ -1,18 +1,17 @@
 ﻿using Carbunql.Extensions;
 using Carbunql.Values;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Carbunql.Analysis.Parser;
 
-public static class WindowFunctionParser
+public static class OverParser
 {
-	public static WindowFunction Parse(string text)
+	public static Over Parse(string text)
 	{
 		using var r = new TokenReader(text);
 		return Parse(r);
 	}
 
-	public static WindowFunction ParseAsInner(ITokenReader r)
+	public static Over ParseAsInner(ITokenReader r)
 	{
 		r.Read("(");
 		using var ir = new BracketInnerTokenReader(r);
@@ -20,12 +19,12 @@ public static class WindowFunctionParser
 		return v;
 	}
 
-	public static WindowFunction Parse(ITokenReader r)
+	public static Over Parse(ITokenReader r)
 	{
 		r.ReadOrDefault("(");
 		var token = r.Read();
 
-		var winfn = new WindowFunction();
+		var winfn = new Over();
 		do
 		{
 			if (token.IsEqualNoCase("partition by"))

--- a/src/Carbunql/Building/WindowFunctionExtension.cs
+++ b/src/Carbunql/Building/WindowFunctionExtension.cs
@@ -5,25 +5,25 @@ namespace Carbunql.Building;
 
 public static class WindowFunctionExtension
 {
-    public static void AddPartition(this WindowFunction source, ValueBase partition)
+    public static void AddPartition(this Over source, ValueBase partition)
     {
         source.PartitionBy ??= new();
         source.PartitionBy.Add(partition);
     }
 
-    public static void AddPartition(this WindowFunction source, Func<ValueBase> partitionbuilder)
+    public static void AddPartition(this Over source, Func<ValueBase> partitionbuilder)
     {
         source.PartitionBy ??= new();
         source.PartitionBy.Add(partitionbuilder());
     }
 
-    public static void AddOrder(this WindowFunction source, SortableItem order)
+    public static void AddOrder(this Over source, SortableItem order)
     {
         source.OrderBy ??= new();
         source.OrderBy.Add(order);
     }
 
-    public static void AddOrder(this WindowFunction source, Func<SortableItem> orderbuilder)
+    public static void AddOrder(this Over source, Func<SortableItem> orderbuilder)
     {
         source.OrderBy ??= new();
         source.OrderBy.Add(orderbuilder());

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -7,7 +7,7 @@
     <Title></Title>
     <Copyright>mk3008net</Copyright>
     <Description>A lightweight library for parsing and building select queries. SQL can be rebuilt dynamically.</Description>
-    <Version>0.3.2</Version>
+    <Version>0.4.0</Version>
     <Authors>mk3008net</Authors>
     <PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/Token.cs
+++ b/src/Carbunql/Token.cs
@@ -72,7 +72,8 @@ public class Token
 			if (Sender is VirtualTable) return true;
 			if (Sender is FunctionTable) return false;
 			if (Sender is FunctionValue) return false;
-			if (Sender is WindowFunction) return false;
+			if (Sender is Filter) return false;
+			if (Sender is Over) return false;
 			return true;
 		}
 		if (Text.Equals("::")) return false;

--- a/src/Carbunql/TokenFormatLogic.cs
+++ b/src/Carbunql/TokenFormatLogic.cs
@@ -59,6 +59,7 @@ public class TokenFormatLogic
 		if (token.Parent != null && token.Parent.Sender is ValuesQuery) return false;
 		if (token.Sender is FunctionValue) return false;
 		if (token.Sender is FunctionTable) return false;
+		if (token.Text.Equals("filter")) return false;
 		if (token.Text.Equals("over")) return false;
 
 		return true;
@@ -73,6 +74,7 @@ public class TokenFormatLogic
 		if (token.Parent.Sender is ValuesQuery) return false;
 		if (token.Sender is FunctionValue) return false;
 		if (token.Sender is FunctionTable) return false;
+		if (token.Text.Equals(")") && token.Parent.Text.IsEqualNoCase("filter")) return true;
 		if (token.Text.Equals(")") && token.Parent.Text.IsEqualNoCase("over")) return true;
 
 		return true;

--- a/src/Carbunql/Values/Filter.cs
+++ b/src/Carbunql/Values/Filter.cs
@@ -1,0 +1,37 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Values;
+
+[MessagePack.MessagePackObject]
+public class Filter : IQueryCommand
+{
+	[MessagePack.Key(0)]
+	public WhereClause? WhereClause { get; set; }
+
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public IEnumerable<Token> GetTokens(Token? parent)
+	{
+		if (WhereClause == null) yield break;
+
+		var filterToken = Token.Reserved(this, parent, "filter");
+		yield return filterToken;
+
+		var bracket = Token.ReservedBracketStart(this, filterToken);
+		yield return bracket;
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetTokens(bracket)) yield return item;
+		}
+		yield return Token.ReservedBracketEnd(this, filterToken);
+	}
+}

--- a/src/Carbunql/Values/FunctionValue.cs
+++ b/src/Carbunql/Values/FunctionValue.cs
@@ -18,11 +18,11 @@ public class FunctionValue : ValueBase
 		Argument = new ValueCollection();
 	}
 
-	public FunctionValue(string name, WindowFunction winfn)
+	public FunctionValue(string name, Over winfn)
 	{
 		Name = name;
 		Argument = new ValueCollection();
-		WindowFunction = winfn;
+		Over = winfn;
 	}
 
 	public FunctionValue(string name, string arg)
@@ -49,51 +49,54 @@ public class FunctionValue : ValueBase
 		};
 	}
 
-	public FunctionValue(string name, Func<WindowFunction> wfbuiilder)
+	public FunctionValue(string name, Func<Over> wfbuiilder)
 	{
 		Name = name;
 		Argument = new ValueCollection();
-		WindowFunction = wfbuiilder();
+		Over = wfbuiilder();
 	}
 
-	public FunctionValue(string name, ValueBase args, WindowFunction winfn)
+	public FunctionValue(string name, ValueBase args, Over winfn)
 	{
 		Name = name;
 		Argument = new ValueCollection
 		{
 			args
 		};
-		WindowFunction = winfn;
+		Over = winfn;
 	}
 
-	public FunctionValue(string name, ValueBase args, Func<WindowFunction> wfbuiilder)
+	public FunctionValue(string name, ValueBase args, Func<Over> wfbuiilder)
 	{
 		Name = name;
 		Argument = new ValueCollection
 		{
 			args
 		};
-		WindowFunction = wfbuiilder();
+		Over = wfbuiilder();
 	}
 
-	public FunctionValue(string name, Func<ValueBase> builder, Func<WindowFunction> wfbuiilder)
+	public FunctionValue(string name, Func<ValueBase> builder, Func<Over> wfbuiilder)
 	{
 		Name = name;
 		Argument = new ValueCollection
 		{
 			builder()
 		};
-		WindowFunction = wfbuiilder();
+		Over = wfbuiilder();
 	}
 
 	[Key(1)]
 	public string Name { get; init; }
 
 	[Key(2)]
-	public ValueCollection Argument { get; init; }
+	public ValueCollection Argument { get; set; }
 
 	[Key(3)]
-	public WindowFunction? WindowFunction { get; init; }
+	public Over? Over { get; set; }
+
+	[Key(4)]
+	public Filter? Filter { get; set; }
 
 	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
@@ -101,9 +104,16 @@ public class FunctionValue : ValueBase
 		{
 			yield return item;
 		}
-		if (WindowFunction != null)
+		if (Filter != null)
 		{
-			foreach (var item in WindowFunction.GetInternalQueries())
+			foreach (var item in Filter.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (Over != null)
+		{
+			foreach (var item in Over.GetInternalQueries())
 			{
 				yield return item;
 			}
@@ -119,9 +129,14 @@ public class FunctionValue : ValueBase
 		foreach (var item in Argument.GetTokens(bracket)) yield return item;
 		yield return Token.ReservedBracketEnd(this, parent);
 
-		if (WindowFunction != null)
+		if (Filter != null)
 		{
-			foreach (var item in WindowFunction.GetTokens(parent)) yield return item;
+			foreach (var item in Filter.GetTokens(parent)) yield return item;
+		}
+
+		if (Over != null)
+		{
+			foreach (var item in Over.GetTokens(parent)) yield return item;
 		}
 	}
 }

--- a/src/Carbunql/Values/Over.cs
+++ b/src/Carbunql/Values/Over.cs
@@ -3,7 +3,7 @@
 namespace Carbunql.Values;
 
 [MessagePack.MessagePackObject]
-public class WindowFunction : IQueryCommand
+public class Over : IQueryCommand
 {
 	[MessagePack.Key(0)]
 	public PartitionClause? PartitionBy { get; set; }

--- a/test/Carbunql.Analysis.Test/SelectQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/SelectQueryParserTest.cs
@@ -507,4 +507,61 @@ limit 10";
 		var lst = item.GetTokens().ToList();
 		Assert.Equal(6, lst.Count);
 	}
+
+	[Fact]
+	public void WindowFunction_Filter()
+	{
+		var text = @"
+with
+v (id, name, value) as (
+    values
+    (1, 'a', 10)
+    , (2, 'a', 20)
+    , (3, 'b', 50)
+    , (4, 'c', 70)
+)
+select  
+    sum(value) filter (where v.name = 'a') as value_a
+    , sum(value) filter (where v.name = 'b') as value_b
+    , sum(value) filter (where v.name = 'c') as value_b
+from
+    v
+";
+
+		var item = QueryParser.Parse(text) as SelectQuery;
+		if (item == null) throw new Exception();
+		Monitor.Log(item);
+
+		var lst = item.GetTokens().ToList();
+		Assert.Equal(94, lst.Count);
+	}
+
+	[Fact]
+	public void WindowFunction_Filter_Over()
+	{
+		var text = @"
+with
+v (id, name, value) as (
+    values
+    (1, 'a', 10)
+    , (2, 'a', 20)
+    , (3, 'b', 50)
+    , (4, 'c', 70)
+)
+select  
+    id
+    , name
+    , value
+    , string_agg(id::text, ',') filter (where v.name = 'a') over (partition by name order by value) as text
+from
+    v
+";
+
+		var item = QueryParser.Parse(text) as SelectQuery;
+		if (item == null) throw new Exception();
+		Monitor.Log(item);
+
+		var lst = item.GetTokens().ToList();
+		Assert.Equal(79, lst.Count);
+	}
 }

--- a/test/Carbunql.Analysis.Test/ValueParseTest.cs
+++ b/test/Carbunql.Analysis.Test/ValueParseTest.cs
@@ -319,6 +319,17 @@ public class ValueParserTest
 	}
 
 	[Fact]
+	public void WindowFunction_Filter()
+	{
+		var text = "sum(value) filter (where v.name = 'a')";
+		var v = ValueParser.Parse(text);
+		Monitor.Log(v);
+
+		var lst = v.GetTokens().ToList();
+		Assert.Equal(13, lst.Count);
+	}
+
+	[Fact]
 	public void CaseExpression()
 	{
 		var text = "case tbl.col when 1 then 10 when 2 then 20 else 30 end";

--- a/test/Carbunql.Building.Test/FunctionTest.cs
+++ b/test/Carbunql.Building.Test/FunctionTest.cs
@@ -46,7 +46,7 @@ public class FunctionTest
 		var (f, a) = sq.From("table_a").As("a");
 		sq.Select(() =>
 		{
-			var wf = new WindowFunction();
+			var wf = new Over();
 			wf.AddPartition(new ColumnValue(a, "parent_id"));
 			wf.AddOrder(new ColumnValue(a, "id").ToSortable());
 			return new FunctionValue("row_number", wf);

--- a/test/Carbunql.Building.Test/SerializeTest.Query.cs
+++ b/test/Carbunql.Building.Test/SerializeTest.Query.cs
@@ -198,4 +198,33 @@ ORDER BY
 
 		Assert.Equal(TruncateControlString(sq.ToText()), TruncateControlString(actual!.ToText()));
 	}
+
+	[Fact]
+	public void SampleQuery_WindowFunction()
+	{
+		var sq = new SelectQuery(@"
+with
+v (id, name, value) as (
+    values
+    (1, 'a', 10)
+    , (2, 'a', 20)
+    , (3, 'b', 50)
+    , (4, 'c', 70)
+)
+select  
+    id
+    , name
+    , value
+    , string_agg(id::text, ',') filter (where v.name = 'a') over (partition by name order by value) as text
+from
+    v");
+
+		var json = MessagePackSerializer.Serialize(sq);
+		Output.WriteLine(MessagePackSerializer.ConvertToJson(json));
+
+		var actual = MessagePackSerializer.Deserialize<SelectQuery>(json);
+		Output.WriteLine(actual.ToText());
+
+		Assert.Equal(TruncateControlString(sq.ToText()), TruncateControlString(actual!.ToText()));
+	}
 }

--- a/test/Carbunql.Building.Test/SerializeTest.ValueBase.cs
+++ b/test/Carbunql.Building.Test/SerializeTest.ValueBase.cs
@@ -229,7 +229,7 @@ public partial class SerializeTest
 	[Fact]
 	public void WindowFunction()
 	{
-		var win = new WindowFunction();
+		var win = new Over();
 		win.AddPartition(new ColumnValue("shop_id"));
 		win.AddOrder(new Clauses.SortableItem(new ColumnValue("order_id")));
 


### PR DESCRIPTION
The WindowFunction class was no longer an appropriate name, so I changed it to the Over class. Along with this, various class names have also been changed. With the class name change, compatibility has also disappeared.