### PR TITLE
#192 Added automatic integration feature for nested With clauses

### DIFF
--- a/src/Carbunql/Building/FromClauseExtension.cs
+++ b/src/Carbunql/Building/FromClauseExtension.cs
@@ -41,7 +41,6 @@ public static class FromClauseExtension
 
 	public static FromClause From(this SelectQuery source, IReadQuery subQuery)
 	{
-		source.ImportCommonTable(subQuery);
 		var vt = new VirtualTable(subQuery);
 		var st = vt.ToSelectable("q");
 		return source.From(st);

--- a/src/Carbunql/Building/ReadQueryExtension.cs
+++ b/src/Carbunql/Building/ReadQueryExtension.cs
@@ -17,7 +17,6 @@ public static class ReadQueryExtension
 	public static (SelectQuery, CommonTable) ToCTE(this IReadQuery source, string alias)
 	{
 		var sq = new SelectQuery();
-		sq.ImportCommonTable(source);
 
 		sq.WithClause ??= new WithClause();
 		var ct = source.ToCommonTable(alias);

--- a/src/Carbunql/Building/SelectQueryExtension.cs
+++ b/src/Carbunql/Building/SelectQueryExtension.cs
@@ -1,11 +1,10 @@
 ﻿using Carbunql.Clauses;
-using Carbunql.Values;
-using System.Diagnostics.Tracing;
 
 namespace Carbunql.Building;
 
 public static class QueryBaseExtension
 {
+	[Obsolete("With clauses do not need to be manually imported.")]
 	public static SelectQuery ImportCommonTable(this SelectQuery source, IReadQuery tagert)
 	{
 		var w = tagert.GetWithClause();
@@ -21,7 +20,6 @@ public static class QueryBaseExtension
 
 	public static CommonTable With(this SelectQuery source, IReadQuery q)
 	{
-		source.ImportCommonTable(q);
 		return source.With(q.ToCommonTable("cte"));
 	}
 
@@ -39,7 +37,6 @@ public static class QueryBaseExtension
 
 	public static CommonTable With(this SelectQuery source, ValuesQuery q, IEnumerable<string> columnAliases)
 	{
-		source.ImportCommonTable(q);
 		return source.With(q.ToCommonTable("cte", columnAliases));
 	}
 

--- a/src/Carbunql/Clauses/BetweenClause.cs
+++ b/src/Carbunql/Clauses/BetweenClause.cs
@@ -1,4 +1,6 @@
-﻿using MessagePack;
+﻿using Carbunql.Extensions;
+using Carbunql.Tables;
+using MessagePack;
 
 namespace Carbunql.Clauses;
 
@@ -29,7 +31,7 @@ public class BetweenClause : ValueBase
 
 	public bool IsNegative { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Value.GetInternalQueries())
 		{
@@ -40,6 +42,46 @@ public class BetweenClause : ValueBase
 			yield return item;
 		}
 		foreach (var item in End.GetInternalQueries())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Value.GetParameters();
+		prm = prm.Merge(Start.GetParameters());
+		prm = prm.Merge(End.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Start.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in End.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Start.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in End.GetCommonTables())
 		{
 			yield return item;
 		}

--- a/src/Carbunql/Clauses/CommentClause.cs
+++ b/src/Carbunql/Clauses/CommentClause.cs
@@ -1,5 +1,4 @@
 ﻿using Carbunql.Tables;
-using MessagePack;
 using System.Collections;
 
 namespace Carbunql.Clauses;
@@ -32,6 +31,11 @@ public class CommentClause : IList<string>, IQueryCommandable
 	public void CopyTo(string[] array, int arrayIndex)
 	{
 		((ICollection<string>)Collection).CopyTo(array, arrayIndex);
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		yield break;
 	}
 
 	public IEnumerator<string> GetEnumerator()

--- a/src/Carbunql/Clauses/CommonTable.cs
+++ b/src/Carbunql/Clauses/CommonTable.cs
@@ -33,4 +33,9 @@ public class CommonTable : SelectableTable
 	public bool IsSelectQuery => Table.IsSelectQuery;
 
 	public SelectQuery GetSelectQuery() => Table.GetSelectQuery();
+
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		yield return this;
+	}
 }

--- a/src/Carbunql/Clauses/CreateTableClause.cs
+++ b/src/Carbunql/Clauses/CreateTableClause.cs
@@ -1,38 +1,79 @@
 ﻿using Carbunql.Extensions;
+using Carbunql.Tables;
 
 namespace Carbunql.Clauses;
 
-public class CreateTableClause : IQueryCommand
+public class CreateTableClause : IQueryCommandable
 {
-    public CreateTableClause()
-    {
-    }
+	public CreateTableClause()
+	{
+	}
 
-    public CreateTableClause(TableBase table)
-    {
-        Table = table;
-    }
+	public CreateTableClause(TableBase table)
+	{
+		Table = table;
+	}
 
-    public bool IsTemporary { get; set; } = true;
+	public bool IsTemporary { get; set; } = true;
 
-    public TableBase? Table { get; set; }
+	public TableBase? Table { get; set; }
 
-    public IEnumerable<Token> GetTokens(Token? parent)
-    {
-        if (Table == null) throw new Exception();
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Table != null)
+		{
+			foreach (var item in Table.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
 
-        Token clause = GetClauseToken(parent);
-        yield return clause;
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		if (Table != null)
+		{
+			foreach (var item in Table.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+	}
 
-        foreach (var item in Table.GetTokens(clause)) yield return item;
-    }
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		if (Table != null)
+		{
+			foreach (var item in Table.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+	}
 
-    private Token GetClauseToken(Token? parent)
-    {
-        if (IsTemporary)
-        {
-            return Token.Reserved(this, parent, "create temporary table");
-        }
-        return Token.Reserved(this, parent, "create table");
-    }
+	public IDictionary<string, object?> GetParameters()
+	{
+		var prm = EmptyParameters.Get();
+		prm = prm.Merge(Table?.GetParameters());
+		return prm;
+	}
+
+	public IEnumerable<Token> GetTokens(Token? parent)
+	{
+		if (Table == null) throw new Exception();
+
+		Token clause = GetClauseToken(parent);
+		yield return clause;
+
+		foreach (var item in Table.GetTokens(clause)) yield return item;
+	}
+
+	private Token GetClauseToken(Token? parent)
+	{
+		if (IsTemporary)
+		{
+			return Token.Reserved(this, parent, "create temporary table");
+		}
+		return Token.Reserved(this, parent, "create table");
+	}
 }

--- a/src/Carbunql/Clauses/DeleteClause.cs
+++ b/src/Carbunql/Clauses/DeleteClause.cs
@@ -2,7 +2,7 @@
 
 namespace Carbunql.Clauses;
 
-public class DeleteClause : IQueryCommand
+public class DeleteClause : IQueryCommandable
 {
 	public DeleteClause(SelectableTable table)
 	{
@@ -29,6 +29,19 @@ public class DeleteClause : IQueryCommand
 	public IEnumerable<PhysicalTable> GetPhysicalTables()
 	{
 		foreach (var item in Table.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		return Table.GetParameters();
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
 		{
 			yield return item;
 		}

--- a/src/Carbunql/Clauses/FromClause.cs
+++ b/src/Carbunql/Clauses/FromClause.cs
@@ -53,6 +53,24 @@ public class FromClause : IQueryCommandable
 			}
 		}
 	}
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Root.GetCommonTables())
+		{
+			yield return item;
+		}
+
+		if (Relations != null)
+		{
+			foreach (var relation in Relations)
+			{
+				foreach (var item in relation.GetCommonTables())
+				{
+					yield return item;
+				}
+			}
+		}
+	}
 
 	public IDictionary<string, object?> GetParameters()
 	{

--- a/src/Carbunql/Clauses/GroupClause.cs
+++ b/src/Carbunql/Clauses/GroupClause.cs
@@ -43,6 +43,17 @@ public class GroupClause : IList<ValueBase>, IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var value in Items)
+		{
+			foreach (var item in value.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		var clause = Token.Reserved(this, parent, "group by");

--- a/src/Carbunql/Clauses/HavingClause.cs
+++ b/src/Carbunql/Clauses/HavingClause.cs
@@ -29,6 +29,14 @@ public class HavingClause : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Condition.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		return Condition.GetParameters();

--- a/src/Carbunql/Clauses/InClause.cs
+++ b/src/Carbunql/Clauses/InClause.cs
@@ -1,4 +1,6 @@
-﻿using Carbunql.Values;
+﻿using Carbunql.Extensions;
+using Carbunql.Tables;
+using Carbunql.Values;
 using MessagePack;
 
 namespace Carbunql.Clauses;
@@ -45,7 +47,7 @@ public class InClause : ValueBase
 
 	public ValueBase Argument { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Value.GetInternalQueries())
 		{
@@ -67,5 +69,36 @@ public class InClause : ValueBase
 
 		yield return Token.Reserved(this, parent, "in");
 		foreach (var item in Argument.GetTokens(parent)) yield return item;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Value.GetParameters();
+		prm = prm.Merge(Argument.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Argument.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Argument.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Clauses/InsertClause.cs
+++ b/src/Carbunql/Clauses/InsertClause.cs
@@ -1,18 +1,49 @@
-﻿namespace Carbunql.Clauses;
+﻿using Carbunql.Tables;
 
-public class InsertClause : IQueryCommand
+namespace Carbunql.Clauses;
+
+public class InsertClause : IQueryCommandable
 {
-    public InsertClause(SelectableTable table)
-    {
-        Table = table;
-    }
+	public InsertClause(SelectableTable table)
+	{
+		Table = table;
+	}
 
-    public SelectableTable Table { get; init; }
+	public SelectableTable Table { get; init; }
 
-    public IEnumerable<Token> GetTokens(Token? parent)
-    {
-        var t = Token.Reserved(this, parent, "insert into");
-        yield return t;
-        foreach (var item in Table.GetTokens(t)) yield return item;
-    }
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		foreach (var item in Table.GetInternalQueries())
+		{
+			yield return item;
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		return Table.GetParameters();
+	}
+
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		foreach (var item in Table.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<Token> GetTokens(Token? parent)
+	{
+		var t = Token.Reserved(this, parent, "insert into");
+		yield return t;
+		foreach (var item in Table.GetTokens(t)) yield return item;
+	}
 }

--- a/src/Carbunql/Clauses/LimitClause.cs
+++ b/src/Carbunql/Clauses/LimitClause.cs
@@ -64,6 +64,22 @@ public class LimitClause : IQueryCommandable
 		}
 	}
 
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Condition.GetCommonTables())
+		{
+			yield return item;
+		}
+		if (Offset != null)
+		{
+			foreach (var item in Offset.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		var prm = Condition.GetParameters();

--- a/src/Carbunql/Clauses/MergeClause.cs
+++ b/src/Carbunql/Clauses/MergeClause.cs
@@ -32,6 +32,14 @@ public class MergeClause : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		var t = Token.Reserved(this, parent, "merge into");

--- a/src/Carbunql/Clauses/MergeCondition.cs
+++ b/src/Carbunql/Clauses/MergeCondition.cs
@@ -35,6 +35,17 @@ public abstract class MergeCondition : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Condition != null)
+		{
+			foreach (var item in Condition.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public abstract IDictionary<string, object?> GetParameters();
 
 	public abstract IEnumerable<Token> GetTokens(Token? parent);

--- a/src/Carbunql/Clauses/MergeInsertClause.cs
+++ b/src/Carbunql/Clauses/MergeInsertClause.cs
@@ -1,8 +1,9 @@
-﻿using Carbunql.Values;
+﻿using Carbunql.Tables;
+using Carbunql.Values;
 
 namespace Carbunql.Clauses;
 
-public class MergeInsertClause : IQueryCommand
+public class MergeInsertClause : IQueryCommandable
 {
 	public MergeInsertClause(ValueCollection columnAliases)
 	{
@@ -24,5 +25,29 @@ public class MergeInsertClause : IQueryCommand
 	public virtual IDictionary<string, object?> GetParameters()
 	{
 		return ColumnAliases.GetParameters();
+	}
+
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		foreach (var item in ColumnAliases.GetInternalQueries())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		foreach (var item in ColumnAliases.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in ColumnAliases.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Clauses/MergeSetClause.cs
+++ b/src/Carbunql/Clauses/MergeSetClause.cs
@@ -4,6 +4,17 @@ namespace Carbunql.Clauses;
 
 public class MergeSetClause : QueryCommandCollection<ValueBase>, IQueryCommandable
 {
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var value in Items)
+		{
+			foreach (var item in value.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
 		foreach (var value in Items)

--- a/src/Carbunql/Clauses/NamedWindowDefinition.cs
+++ b/src/Carbunql/Clauses/NamedWindowDefinition.cs
@@ -37,6 +37,11 @@ public class NamedWindowDefinition : IQueryCommandable
 		foreach (var item in WindowDefinition.GetPhysicalTables()) yield return item;
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in WindowDefinition.GetCommonTables()) yield return item;
+	}
+
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		yield return new Token(this, parent, Alias); ;

--- a/src/Carbunql/Clauses/OrderClause.cs
+++ b/src/Carbunql/Clauses/OrderClause.cs
@@ -36,6 +36,17 @@ public class OrderClause : QueryCommandCollection<IQueryCommandable>, IQueryComm
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var value in Items)
+		{
+			foreach (var item in value.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public override IEnumerable<Token> GetTokens(Token? parent)
 	{
 		if (!Items.Any()) yield break;

--- a/src/Carbunql/Clauses/OverClause.cs
+++ b/src/Carbunql/Clauses/OverClause.cs
@@ -1,13 +1,14 @@
-﻿using MessagePack;
+﻿using Carbunql.Tables;
+using MessagePack;
 
 namespace Carbunql.Clauses;
 
 [MessagePackObject(keyAsPropertyName: true)]
-public class OverClause : IQueryCommand
+public class OverClause : IQueryCommandable
 {
-    public OverClause()
-    {
-        WindowDefinition = null!;
+	public OverClause()
+	{
+		WindowDefinition = null!;
 	}
 
 	public OverClause(WindowDefinition definition)
@@ -17,19 +18,40 @@ public class OverClause : IQueryCommand
 
 	public WindowDefinition WindowDefinition { get; set; }
 
-    public IEnumerable<SelectQuery> GetInternalQueries()
-    {
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in WindowDefinition.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
 		foreach (var item in WindowDefinition.GetInternalQueries())
 		{
 			yield return item;
 		}
 	}
 
-    public IEnumerable<Token> GetTokens(Token? parent)
-    {
-        var overToken = Token.Reserved(this, parent, "over");
-        yield return overToken;
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		foreach (var item in WindowDefinition.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
 
-        foreach (var item in WindowDefinition.GetTokens(overToken)) yield return item;
-    }
+	public IDictionary<string, object?> GetParameters()
+	{
+		return WindowDefinition.GetParameters();
+	}
+
+	public IEnumerable<Token> GetTokens(Token? parent)
+	{
+		var overToken = Token.Reserved(this, parent, "over");
+		yield return overToken;
+
+		foreach (var item in WindowDefinition.GetTokens(overToken)) yield return item;
+	}
 }

--- a/src/Carbunql/Clauses/PartitionClause.cs
+++ b/src/Carbunql/Clauses/PartitionClause.cs
@@ -36,6 +36,17 @@ public class PartitionClause : QueryCommandCollection<ValueBase>, IQueryCommanda
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var value in Items)
+		{
+			foreach (var item in value.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public override IEnumerable<Token> GetTokens(Token? parent)
 	{
 		if (!Items.Any()) yield break;

--- a/src/Carbunql/Clauses/Relation.cs
+++ b/src/Carbunql/Clauses/Relation.cs
@@ -63,6 +63,22 @@ public class Relation : IQueryCommandable
 		}
 	}
 
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
+		{
+			yield return item;
+		}
+		if (Condition != null)
+		{
+			foreach (var item in Condition.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		var prm = EmptyParameters.Get();

--- a/src/Carbunql/Clauses/ReturningClause.cs
+++ b/src/Carbunql/Clauses/ReturningClause.cs
@@ -2,7 +2,7 @@
 
 namespace Carbunql.Clauses;
 
-public class ReturningClause : IQueryCommand
+public class ReturningClause : IQueryCommandable
 {
 	public ReturningClause(ValueBase value)
 	{
@@ -29,6 +29,19 @@ public class ReturningClause : IQueryCommand
 	public IEnumerable<PhysicalTable> GetPhysicalTables()
 	{
 		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		return Value.GetParameters();
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Value.GetCommonTables())
 		{
 			yield return item;
 		}

--- a/src/Carbunql/Clauses/SelectClause.cs
+++ b/src/Carbunql/Clauses/SelectClause.cs
@@ -58,6 +58,25 @@ public class SelectClause : QueryCommandCollection<SelectableItem>, IQueryComman
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Top != null)
+		{
+			foreach (var item in Top.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+
+		foreach (var value in Items)
+		{
+			foreach (var item in value.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public override IEnumerable<Token> GetTokens(Token? parent)
 	{
 		Token clause = GetClauseToken(parent);

--- a/src/Carbunql/Clauses/SelectableItem.cs
+++ b/src/Carbunql/Clauses/SelectableItem.cs
@@ -37,6 +37,14 @@ public class SelectableItem : IQueryCommandable, ISelectable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		foreach (var item in Value.GetTokens(parent)) yield return item;

--- a/src/Carbunql/Clauses/SelectableTable.cs
+++ b/src/Carbunql/Clauses/SelectableTable.cs
@@ -95,4 +95,12 @@ public class SelectableTable : IQueryCommandable, ISelectable
 			yield return item;
 		}
 	}
+
+	public virtual IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
 }

--- a/src/Carbunql/Clauses/SetClause.cs
+++ b/src/Carbunql/Clauses/SetClause.cs
@@ -1,7 +1,42 @@
-﻿namespace Carbunql.Clauses;
+﻿using Carbunql.Tables;
 
-public class SetClause : QueryCommandCollection<ValueBase>, IQueryCommand
+namespace Carbunql.Clauses;
+
+public class SetClause : QueryCommandCollection<ValueBase>, IQueryCommandable
 {
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var x in Items)
+		{
+			foreach (var item in x.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		foreach (var x in Items)
+		{
+			foreach (var item in x.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		foreach (var x in Items)
+		{
+			foreach (var item in x.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public override IEnumerable<Token> GetTokens(Token? parent)
 	{
 		Token clause = GetClauseToken(parent);

--- a/src/Carbunql/Clauses/SortableItem.cs
+++ b/src/Carbunql/Clauses/SortableItem.cs
@@ -36,6 +36,14 @@ public class SortableItem : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		return Value.GetParameters();

--- a/src/Carbunql/Clauses/TableBase.cs
+++ b/src/Carbunql/Clauses/TableBase.cs
@@ -53,4 +53,6 @@ public abstract class TableBase : IQueryCommandable
 	public abstract IEnumerable<SelectQuery> GetInternalQueries();
 
 	public abstract IEnumerable<PhysicalTable> GetPhysicalTables();
+
+	public abstract IEnumerable<CommonTable> GetCommonTables();
 }

--- a/src/Carbunql/Clauses/UpdateClause.cs
+++ b/src/Carbunql/Clauses/UpdateClause.cs
@@ -2,7 +2,7 @@
 
 namespace Carbunql.Clauses;
 
-public class UpdateClause : IQueryCommand
+public class UpdateClause : IQueryCommandable
 {
 	public UpdateClause(SelectableTable table)
 	{
@@ -32,5 +32,18 @@ public class UpdateClause : IQueryCommand
 		{
 			yield return item;
 		}
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Table.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		throw new NotImplementedException();
 	}
 }

--- a/src/Carbunql/Clauses/UsingClause.cs
+++ b/src/Carbunql/Clauses/UsingClause.cs
@@ -42,6 +42,19 @@ public class UsingClause : IQueryCommandable
 		}
 	}
 
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Root.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Condition.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		var prm = EmptyParameters.Get();

--- a/src/Carbunql/Clauses/ValueBase.cs
+++ b/src/Carbunql/Clauses/ValueBase.cs
@@ -33,6 +33,14 @@ public abstract class ValueBase : IQueryCommandable
 		return value;
 	}
 
+
+	public virtual IDictionary<string, object?> GetParameters()
+	{
+		var prm = GetParametersCore();
+		prm = prm.Merge(OperatableValue?.GetParameters());
+		return prm;
+	}
+
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
 		foreach (var item in GetInternalQueriesCore())
@@ -63,15 +71,28 @@ public abstract class ValueBase : IQueryCommandable
 		}
 	}
 
-	internal virtual IEnumerable<SelectQuery> GetInternalQueriesCore()
+	public IEnumerable<CommonTable> GetCommonTables()
 	{
-		yield break;
+		foreach (var item in GetCommonTablesCore())
+		{
+			yield return item;
+		}
+		if (OperatableValue != null)
+		{
+			foreach (var item in OperatableValue.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
 	}
 
-	internal virtual IEnumerable<PhysicalTable> GetPhysicalTablesCore()
-	{
-		yield break;
-	}
+	protected abstract IDictionary<string, object?> GetParametersCore();
+
+	protected abstract IEnumerable<SelectQuery> GetInternalQueriesCore();
+
+	protected abstract IEnumerable<PhysicalTable> GetPhysicalTablesCore();
+
+	protected abstract IEnumerable<CommonTable> GetCommonTablesCore();
 
 	public abstract IEnumerable<Token> GetCurrentTokens(Token? parent);
 
@@ -98,10 +119,5 @@ public abstract class ValueBase : IQueryCommandable
 	public string ToText()
 	{
 		return GetTokens(null).ToText();
-	}
-
-	public virtual IDictionary<string, object?> GetParameters()
-	{
-		return EmptyParameters.Get();
 	}
 }

--- a/src/Carbunql/Clauses/WhenClause.cs
+++ b/src/Carbunql/Clauses/WhenClause.cs
@@ -30,6 +30,17 @@ public class WhenClause : IList<MergeCondition>, IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var condition in Conditions)
+		{
+			foreach (var item in condition.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IDictionary<string, object?> GetParameters()
 	{
 		var prm = EmptyParameters.Get();

--- a/src/Carbunql/Clauses/WhereClause.cs
+++ b/src/Carbunql/Clauses/WhereClause.cs
@@ -40,4 +40,12 @@ public class WhereClause : IQueryCommandable
 			yield return item;
 		}
 	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Condition.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
 }

--- a/src/Carbunql/Clauses/WindowClause.cs
+++ b/src/Carbunql/Clauses/WindowClause.cs
@@ -51,6 +51,17 @@ public class WindowClause : IList<NamedWindowDefinition>, IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var definition in NamedWindowDefinitions)
+		{
+			foreach (var item in definition.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		if (!NamedWindowDefinitions.Any()) yield break;
@@ -130,6 +141,5 @@ public class WindowClause : IList<NamedWindowDefinition>, IQueryCommandable
 	{
 		return ((IEnumerable)NamedWindowDefinitions).GetEnumerator();
 	}
-
 	#endregion
 }

--- a/src/Carbunql/Clauses/WindowDefinition.cs
+++ b/src/Carbunql/Clauses/WindowDefinition.cs
@@ -34,7 +34,7 @@ public class WindowDefinition : IQueryCommandable
 
 	public string Name { get; set; } = string.Empty;
 
-    public PartitionClause? PartitionBy { get; set; }
+	public PartitionClause? PartitionBy { get; set; }
 
 	public OrderClause? OrderBy { get; set; }
 
@@ -88,6 +88,21 @@ public class WindowDefinition : IQueryCommandable
 		if (OrderBy != null)
 		{
 			foreach (var item in OrderBy.GetPhysicalTables()) yield return item;
+		}
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (!string.IsNullOrEmpty(Name)) yield break;
+		if (PartitionBy == null && OrderBy == null) yield break;
+
+		if (PartitionBy != null)
+		{
+			foreach (var item in PartitionBy.GetCommonTables()) yield return item;
+		}
+		if (OrderBy != null)
+		{
+			foreach (var item in OrderBy.GetCommonTables()) yield return item;
 		}
 	}
 

--- a/src/Carbunql/CommandTextBuilder.cs
+++ b/src/Carbunql/CommandTextBuilder.cs
@@ -32,7 +32,7 @@ public class CommandTextBuilder
         PrevToken = null;
     }
 
-    public string Execute(IQueryCommand cmd)
+    public string Execute(IQueryCommandable cmd)
     {
         return Execute(cmd.GetTokens());
     }

--- a/src/Carbunql/CreateTableQuery.cs
+++ b/src/Carbunql/CreateTableQuery.cs
@@ -19,23 +19,19 @@ public class CreateTableQuery : IQueryCommandable
 
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
-		if (Query != null)
+		if (Query == null) yield break;
+		foreach (var item in Query.GetInternalQueries())
 		{
-			foreach (var item in Query.GetInternalQueries())
-			{
-				yield return item;
-			}
+			yield return item;
 		}
 	}
 
 	public IEnumerable<PhysicalTable> GetPhysicalTables()
 	{
-		if (Query != null)
+		if (Query == null) yield break;
+		foreach (var item in Query.GetPhysicalTables())
 		{
-			foreach (var item in Query.GetPhysicalTables())
-			{
-				yield return item;
-			}
+			yield return item;
 		}
 	}
 
@@ -55,5 +51,11 @@ public class CreateTableQuery : IQueryCommandable
 		yield return t;
 
 		foreach (var item in Query.GetTokens()) yield return item;
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Query == null) yield break;
+		foreach (var item in Query.GetCommonTables()) yield return item;
 	}
 }

--- a/src/Carbunql/DeleteQuery.cs
+++ b/src/Carbunql/DeleteQuery.cs
@@ -98,4 +98,36 @@ public class DeleteQuery : IQueryCommandable, IReturning
 		if (ReturningClause == null) yield break;
 		foreach (var item in ReturningClause.GetTokens(parent)) yield return item;
 	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (DeleteClause != null)
+		{
+			foreach (var item in DeleteClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (ReturningClause != null)
+		{
+			foreach (var item in ReturningClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
 }

--- a/src/Carbunql/IQueryCommand.cs
+++ b/src/Carbunql/IQueryCommand.cs
@@ -1,6 +1,0 @@
-﻿namespace Carbunql;
-
-public interface IQueryCommand
-{
-	IEnumerable<Token> GetTokens(Token? parent);
-}

--- a/src/Carbunql/IQueryCommandExtension.cs
+++ b/src/Carbunql/IQueryCommandExtension.cs
@@ -1,9 +1,0 @@
-﻿namespace Carbunql;
-
-public static class IQueryCommandExtension
-{
-    public static IEnumerable<Token> GetTokens(this IQueryCommand source)
-    {
-        return source.GetTokens(null);
-    }
-}

--- a/src/Carbunql/IQueryCommandable.cs
+++ b/src/Carbunql/IQueryCommandable.cs
@@ -54,17 +54,26 @@ namespace Carbunql;
 [Union(43, typeof(MergeWhenInsert))]
 [Union(44, typeof(MergeWhenNothing))]
 [Union(45, typeof(MergeWhenUpdate))]
-public interface IQueryCommandable : IQueryCommand
+public interface IQueryCommandable
 {
+	IEnumerable<Token> GetTokens(Token? parent);
+
 	IDictionary<string, object?> GetParameters();
 
 	IEnumerable<SelectQuery> GetInternalQueries();
 
 	IEnumerable<PhysicalTable> GetPhysicalTables();
+
+	IEnumerable<CommonTable> GetCommonTables();
 }
 
 public static class IQueryCommandableExtension
 {
+	public static IEnumerable<Token> GetTokens(this IQueryCommandable source)
+	{
+		return source.GetTokens(null);
+	}
+
 	public static QueryCommand ToCommand(this IQueryCommandable source)
 	{
 		var builder = new CommandTextBuilder();

--- a/src/Carbunql/InsertQuery.cs
+++ b/src/Carbunql/InsertQuery.cs
@@ -34,6 +34,17 @@ public class InsertQuery : IQueryCommandable, IReturning
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Query != null)
+		{
+			foreach (var item in Query.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public IDictionary<string, object?>? Parameters { get; set; }
 
 	public virtual IDictionary<string, object?> GetParameters()

--- a/src/Carbunql/MergeInsertQuery.cs
+++ b/src/Carbunql/MergeInsertQuery.cs
@@ -1,4 +1,5 @@
-﻿using Carbunql.Extensions;
+﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
 using Carbunql.Tables;
 using Carbunql.Values;
 
@@ -53,6 +54,23 @@ public class MergeInsertQuery : IQueryCommandable
 			}
 		}
 	}
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Datasource != null)
+		{
+			foreach (var item in Datasource.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (Destination != null)
+		{
+			foreach (var item in Destination.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
 
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
@@ -86,5 +104,4 @@ public class MergeInsertQuery : IQueryCommandable
 		foreach (var item in Datasource.GetTokens(bracket)) yield return item;
 		yield return Token.ReservedBracketEnd(this, parent);
 	}
-
 }

--- a/src/Carbunql/MergeQuery.cs
+++ b/src/Carbunql/MergeQuery.cs
@@ -98,6 +98,32 @@ public class MergeQuery : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		foreach (var item in MergeClause.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in UsingClause.GetCommonTables())
+		{
+			yield return item;
+		}
+		if (WhenClause != null)
+		{
+			foreach (var item in WhenClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public virtual IDictionary<string, object?> GetParameters()
 	{
 		var prm = EmptyParameters.Get();

--- a/src/Carbunql/MergeUpdateQuery.cs
+++ b/src/Carbunql/MergeUpdateQuery.cs
@@ -30,6 +30,17 @@ public class MergeUpdateQuery : IQueryCommandable
 		}
 	}
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (SetClause != null)
+		{
+			foreach (var item in SetClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public virtual IDictionary<string, object?> GetParameters()
 	{
 		var prm = EmptyParameters.Get();

--- a/src/Carbunql/OperatableQuery.cs
+++ b/src/Carbunql/OperatableQuery.cs
@@ -50,4 +50,12 @@ public class OperatableQuery : IQueryCommandable
 			yield return item;
 		}
 	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Query.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
 }

--- a/src/Carbunql/ReadQuery.cs
+++ b/src/Carbunql/ReadQuery.cs
@@ -28,6 +28,8 @@ public abstract class ReadQuery : IReadQuery
 
 	public abstract IEnumerable<PhysicalTable> GetPhysicalTables();
 
+	public abstract IEnumerable<CommonTable> GetCommonTables();
+
 	public IDictionary<string, object?> Parameters { get; set; } = new Dictionary<string, object?>();
 
 	public virtual IDictionary<string, object?> GetInnerParameters() => EmptyParameters.Get();

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -49,7 +49,11 @@ public class SelectQuery : ReadQuery, IQueryCommandable
 
 		if (SelectClause == null) yield break;
 
-		if (parent == null && WithClause != null) foreach (var item in WithClause.GetTokens()) yield return item;
+		if (parent == null && WithClause != null)
+		{
+			var lst = GetCommonTables().ToList();
+			foreach (var item in WithClause.GetTokens(parent, lst)) yield return item;
+		}
 		foreach (var item in SelectClause.GetTokens(parent)) yield return item;
 		if (FromClause != null) foreach (var item in FromClause.GetTokens(parent)) yield return item;
 		if (WhereClause != null) foreach (var item in WhereClause.GetTokens(parent)) yield return item;
@@ -255,6 +259,80 @@ public class SelectQuery : ReadQuery, IQueryCommandable
 				{
 					yield return item.Table;
 				}
+			}
+		}
+	}
+
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (OperatableQuery != null)
+		{
+			foreach (var item in OperatableQuery.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (OrderClause != null)
+		{
+			foreach (var item in OrderClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (LimitClause != null)
+		{
+			foreach (var item in LimitClause.GetCommonTables())
+			{
+				yield return item;
 			}
 		}
 	}

--- a/src/Carbunql/Tables/FunctionTable.cs
+++ b/src/Carbunql/Tables/FunctionTable.cs
@@ -64,4 +64,12 @@ public class FunctionTable : TableBase
 			yield return item;
 		}
 	}
+
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Argument.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
 }

--- a/src/Carbunql/Tables/PhysicalTable.cs
+++ b/src/Carbunql/Tables/PhysicalTable.cs
@@ -58,4 +58,9 @@ public class PhysicalTable : TableBase
 	{
 		yield return this;
 	}
+
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		yield break;
+	}
 }

--- a/src/Carbunql/Tables/VirtualTable.cs
+++ b/src/Carbunql/Tables/VirtualTable.cs
@@ -77,4 +77,12 @@ public class VirtualTable : TableBase
 			yield return item;
 		}
 	}
+
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Query.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
 }

--- a/src/Carbunql/UpdateQuery.cs
+++ b/src/Carbunql/UpdateQuery.cs
@@ -91,6 +91,55 @@ public class UpdateQuery : IQueryCommandable, IReturning
 				yield return item;
 			}
 		}
+		if (ReturningClause != null)
+		{
+			foreach (var item in ReturningClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (UpdateClause != null)
+		{
+			foreach (var item in UpdateClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (SetClause != null)
+		{
+			foreach (var value in SetClause.Items)
+			{
+				foreach (var item in value.GetCommonTables())
+				{
+					yield return item;
+				}
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (ReturningClause != null)
+		{
+			foreach (var item in ReturningClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
 	}
 
 	public IDictionary<string, object?>? Parameters { get; set; }
@@ -102,6 +151,7 @@ public class UpdateQuery : IQueryCommandable, IReturning
 		prm = prm.Merge(FromClause?.GetParameters());
 		prm = prm.Merge(WhereClause?.GetParameters());
 		prm = prm.Merge(Parameters);
+		prm = prm.Merge(ReturningClause?.GetParameters());
 		return prm;
 	}
 

--- a/src/Carbunql/Values/AsArgument.cs
+++ b/src/Carbunql/Values/AsArgument.cs
@@ -1,4 +1,6 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -22,7 +24,7 @@ public class AsArgument : ValueBase
 
 	public ValueBase Type { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Value.GetInternalQueries())
 		{
@@ -39,5 +41,36 @@ public class AsArgument : ValueBase
 		foreach (var item in Value.GetTokens(parent)) yield return item;
 		yield return Token.Reserved(this, parent, "as");
 		foreach (var item in Type.GetTokens(parent)) yield return item;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Type.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Type.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Value.GetParameters();
+		prm = prm.Merge(Type.GetParameters());
+		return prm;
 	}
 }

--- a/src/Carbunql/Values/BracketValue.cs
+++ b/src/Carbunql/Values/BracketValue.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -18,9 +19,30 @@ public class BracketValue : ValueBase
 
 	public ValueBase Inner { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Inner.GetInternalQueries())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		return Inner.GetParameters();
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Inner.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Inner.GetCommonTables())
 		{
 			yield return item;
 		}

--- a/src/Carbunql/Values/CastValue.cs
+++ b/src/Carbunql/Values/CastValue.cs
@@ -1,4 +1,6 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -26,7 +28,7 @@ public class CastValue : ValueBase
 
 	public ValueBase Type { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Inner.GetInternalQueries())
 		{
@@ -43,5 +45,36 @@ public class CastValue : ValueBase
 		foreach (var item in Inner.GetTokens(parent)) yield return item;
 		yield return Token.Reserved(this, parent, Symbol);
 		foreach (var item in Type.GetTokens(parent)) yield return item;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Inner.GetParameters();
+		prm = prm.Merge(Type.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Inner.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Type.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Inner.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Type.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Values/ColumnValue.cs
+++ b/src/Carbunql/Values/ColumnValue.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -52,5 +53,25 @@ public class ColumnValue : ValueBase
 	{
 		if (OperatableValue == null) return Column;
 		return string.Empty;
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		yield break;
+	}
+
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	{
+		yield break;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		return EmptyParameters.Get();
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		yield break;
 	}
 }

--- a/src/Carbunql/Values/Filter.cs
+++ b/src/Carbunql/Values/Filter.cs
@@ -1,18 +1,49 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
 
 [MessagePackObject(keyAsPropertyName: true)]
-public class Filter : IQueryCommand
+public class Filter : IQueryCommandable
 {
 	public WhereClause? WhereClause { get; set; }
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
 
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
 		if (WhereClause != null)
 		{
 			foreach (var item in WhereClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		var prm = EmptyParameters.Get();
+		prm = prm.Merge(WhereClause?.GetParameters());
+		return prm;
+	}
+
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetPhysicalTables())
 			{
 				yield return item;
 			}

--- a/src/Carbunql/Values/FromArgument.cs
+++ b/src/Carbunql/Values/FromArgument.cs
@@ -1,4 +1,6 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -22,7 +24,7 @@ public class FromArgument : ValueBase
 
 	public ValueBase Value { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Unit.GetInternalQueries())
 		{
@@ -39,5 +41,36 @@ public class FromArgument : ValueBase
 		foreach (var item in Unit.GetTokens(parent)) yield return item;
 		yield return Token.Reserved(this, parent, "from");
 		foreach (var item in Value.GetTokens(parent)) yield return item;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Unit.GetParameters();
+		prm = prm.Merge(Value.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Unit.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Unit.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Values/FunctionValue.cs
+++ b/src/Carbunql/Values/FunctionValue.cs
@@ -1,4 +1,6 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -94,7 +96,7 @@ public class FunctionValue : ValueBase
 
 	public Filter? Filter { get; set; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Argument.GetInternalQueries())
 		{
@@ -133,6 +135,58 @@ public class FunctionValue : ValueBase
 		if (Over != null)
 		{
 			foreach (var item in Over.GetTokens(parent)) yield return item;
+		}
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Argument.GetParameters();
+		prm = prm.Merge(Filter?.GetParameters());
+		prm = prm.Merge(Over?.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Argument.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		if (Filter != null)
+		{
+			foreach (var item in Filter.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (Over != null)
+		{
+			foreach (var item in Over.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Argument.GetCommonTables())
+		{
+			yield return item;
+		}
+		if (Filter != null)
+		{
+			foreach (var item in Filter.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (Over != null)
+		{
+			foreach (var item in Over.GetCommonTables())
+			{
+				yield return item;
+			}
 		}
 	}
 }

--- a/src/Carbunql/Values/LikeExpression.cs
+++ b/src/Carbunql/Values/LikeExpression.cs
@@ -1,4 +1,6 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 
 namespace Carbunql.Values;
 
@@ -17,7 +19,7 @@ public class LikeExpression : ValueBase
 
 	public bool IsNegative { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Value.GetInternalQueries())
 		{
@@ -37,5 +39,36 @@ public class LikeExpression : ValueBase
 
 		yield return Token.Reserved(this, parent, "like");
 		foreach (var item in Argument.GetTokens(parent)) yield return item;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		var prm = Value.GetParameters();
+		prm = prm.Merge(Argument.GetParameters());
+		return prm;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Argument.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+		foreach (var item in Argument.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Values/LiteralValue.cs
+++ b/src/Carbunql/Values/LiteralValue.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -52,5 +53,25 @@ public class LiteralValue : ValueBase
 	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
 	{
 		yield return new Token(this, parent, CommandText);
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		yield break;
+	}
+
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	{
+		yield break;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		return EmptyParameters.Get();
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		yield break;
 	}
 }

--- a/src/Carbunql/Values/NegativeValue.cs
+++ b/src/Carbunql/Values/NegativeValue.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -18,7 +19,7 @@ public class NegativeValue : ValueBase
 
 	public ValueBase Inner { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
 		foreach (var item in Inner.GetInternalQueries())
 		{
@@ -30,5 +31,26 @@ public class NegativeValue : ValueBase
 	{
 		yield return Token.Reserved(this, parent, "not");
 		foreach (var item in Inner.GetTokens(parent)) yield return item;
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		return Inner.GetParameters();
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Inner.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Inner.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Values/OperatableValue.cs
+++ b/src/Carbunql/Values/OperatableValue.cs
@@ -1,11 +1,12 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
 using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
 
 [MessagePackObject(keyAsPropertyName: true)]
-public class OperatableValue : IQueryCommand
+public class OperatableValue : IQueryCommandable
 {
 	public OperatableValue(string @operator, ValueBase value)
 	{
@@ -17,12 +18,25 @@ public class OperatableValue : IQueryCommand
 
 	public ValueBase Value { get; init; }
 
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
+		}
+	}
+
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
 		foreach (var item in Value.GetInternalQueries())
 		{
 			yield return item;
 		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		return Value.GetParameters();
 	}
 
 	public IEnumerable<PhysicalTable> GetPhysicalTables()

--- a/src/Carbunql/Values/ParameterValue.cs
+++ b/src/Carbunql/Values/ParameterValue.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -29,13 +30,28 @@ public class ParameterValue : ValueBase
 
 	public Dictionary<string, object?> Parameters { get; set; } = new();
 
-	public override IDictionary<string, object?> GetParameters()
+	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+	{
+		yield return new Token(this, parent, Key);
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
 	{
 		return Parameters;
 	}
 
-	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
-		yield return new Token(this, parent, Key);
+		yield break;
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		yield break;
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		yield break;
 	}
 }

--- a/src/Carbunql/Values/QueryContainer.cs
+++ b/src/Carbunql/Values/QueryContainer.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
@@ -18,14 +19,11 @@ public class QueryContainer : ValueBase
 
 	public IQueryCommandable Query { get; init; }
 
-	internal override IEnumerable<SelectQuery> GetInternalQueriesCore()
+	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
 	{
-		if (Query is SelectQuery sq)
+		foreach (var item in Query.GetInternalQueries())
 		{
-			foreach (var item in sq.GetInternalQueries())
-			{
-				yield return item;
-			}
+			yield return item;
 		}
 	}
 
@@ -35,5 +33,26 @@ public class QueryContainer : ValueBase
 		yield return bracket;
 		foreach (var item in Query.GetTokens(bracket)) yield return item;
 		yield return Token.ReservedBracketEnd(this, parent);
+	}
+
+	protected override IDictionary<string, object?> GetParametersCore()
+	{
+		return Query.GetParameters();
+	}
+
+	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+	{
+		foreach (var item in Query.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	protected override IEnumerable<CommonTable> GetCommonTablesCore()
+	{
+		foreach (var item in Query.GetCommonTables())
+		{
+			yield return item;
+		}
 	}
 }

--- a/src/Carbunql/Values/WhenExpression.cs
+++ b/src/Carbunql/Values/WhenExpression.cs
@@ -1,10 +1,12 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+using Carbunql.Tables;
 using MessagePack;
 
 namespace Carbunql.Values;
 
 [MessagePackObject(keyAsPropertyName: true)]
-public class WhenExpression : IQueryCommand
+public class WhenExpression : IQueryCommandable
 {
 	public WhenExpression(ValueBase condition, ValueBase value)
 	{
@@ -54,6 +56,44 @@ public class WhenExpression : IQueryCommand
 		{
 			yield return Token.Reserved(this, parent, "else");
 			foreach (var item in Value.GetTokens(parent)) yield return item;
+		}
+	}
+
+	public IDictionary<string, object?> GetParameters()
+	{
+		var prm = EmptyParameters.Get();
+		prm = prm.Merge(Condition?.GetParameters());
+		prm = prm.Merge(Value.GetParameters());
+		return prm;
+	}
+
+	public IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		if (Condition != null)
+		{
+			foreach (var item in Condition.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		foreach (var item in Value.GetPhysicalTables())
+		{
+			yield return item;
+		}
+	}
+
+	public IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (Condition != null)
+		{
+			foreach (var item in Condition.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		foreach (var item in Value.GetCommonTables())
+		{
+			yield return item;
 		}
 	}
 }

--- a/src/Carbunql/ValuesQuery.cs
+++ b/src/Carbunql/ValuesQuery.cs
@@ -190,6 +190,17 @@ public class ValuesQuery : ReadQuery
 		}
 	}
 
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		foreach (var row in Rows)
+		{
+			foreach (var item in row.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
 	public override SelectQuery GetOrNewSelectQuery()
 	{
 		return ToSelectQuery();

--- a/test/Carbunql.Analysis.Test/QueryCommandMonitor.cs
+++ b/test/Carbunql.Analysis.Test/QueryCommandMonitor.cs
@@ -11,7 +11,7 @@ public class QueryCommandMonitor
         Output = output;
     }
 
-    public void Log(IQueryCommand arg)
+    public void Log(IQueryCommandable arg)
     {
         var frm = new TokenFormatLogic();
         var bld = new CommandTextBuilder(frm);


### PR DESCRIPTION
Integrated IQueryCommand interface with IQueryCommadble interface. It has been abolished because its usage is ambiguous. Added GetCommonTables method to IQueryCommadble interface. Enabled to search nested CommonTables. The With clause allows you to generate tokens from nested CommonTables.