### PR TITLE
#241 Join clause alias name is now automatically obtained

### DIFF
--- a/README_QueryBuilder.md
+++ b/README_QueryBuilder.md
@@ -32,7 +32,7 @@ SelectQuery sq = new SelectQuery();
 // Write the table join expression.
 // Combined expressions can be written in a type-safe manner.
 // Note: Make sure that the join destination table alias name and return value variable name are the same.
-table_b b = from.InnerJoinAs<table_b>("b").On(b => a.a_id == b.a_id);
+table_b b = from.InnerJoinAs<table_b>(b => a.a_id == b.a_id);
 
 // Describe the columns to select.
 // If you want to get all columns, use the SelectAll method

--- a/src/Carbunql.Postgres/JoinExtension.cs
+++ b/src/Carbunql.Postgres/JoinExtension.cs
@@ -1,125 +1,118 @@
 ﻿using Carbunql.Building;
 using Carbunql.Clauses;
+using System;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace Carbunql.Postgres;
 
 public static class JoinExtension
 {
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, string alias)
+	private static T AddRelation<T>(this FromClause source, Func<Relation> relationCreator, Expression<Func<T, bool>> predicate)
+	{
+		var alias = predicate.Parameters[0].Name;
+		var tables = source.GetSelectableTables().Select(x => x.Alias).Distinct().ToList();
+		if (string.IsNullOrEmpty(alias)) throw new NullReferenceException(nameof(alias));
+
+		var relation = relationCreator();
+		relation.As(alias);
+		relation.On((_) => predicate.Body.ToValue(tables));
+
+		return (T)Activator.CreateInstance(typeof(T))!;
+	}
+
+	public static T InnerJoinAs<T>(this FromClause source, Expression<Func<T, bool>> predicate)
 	{
 		var table = typeof(T).ToTableName();
-		return source.InnerJoinAs<T>(table, alias);
+		return source.AddRelation(() => source.InnerJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, string table, string alias)
+	public static T InnerJoinAs<T>(this FromClause source, string table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.InnerJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.InnerJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, CommonTable table, string alias)
+	public static T InnerJoinAs<T>(this FromClause source, CommonTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.InnerJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.InnerJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, SelectableTable table, string alias)
+	public static T InnerJoinAs<T>(this FromClause source, SelectableTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.InnerJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.InnerJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, IReadQuery query, string alias)
+	public static T InnerJoinAs<T>(this FromClause source, IReadQuery query, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.InnerJoin(query);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.InnerJoin(query), predicate);
 	}
 
-	public static JoinBuilder<T> InnerJoinAs<T>(this FromClause source, Func<SelectQuery> builder, string alias)
+	public static T InnerJoinAs<T>(this FromClause source, Func<SelectQuery> builder, Expression<Func<T, bool>> predicate)
 	{
-		return source.InnerJoinAs<T>(builder(), alias);
+		return source.AddRelation(() => source.InnerJoin(builder()), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, Expression<Func<T, bool>> predicate)
 	{
 		var table = typeof(T).ToTableName();
-		return source.LeftJoinAs<T>(table, alias);
+		return source.AddRelation(() => source.LeftJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, string table, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, string table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.LeftJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.LeftJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, CommonTable table, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, CommonTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.LeftJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.LeftJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, SelectableTable table, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, SelectableTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.LeftJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.LeftJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, IReadQuery query, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, IReadQuery query, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.LeftJoin(query);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.LeftJoin(query), predicate);
 	}
 
-	public static JoinBuilder<T> LeftJoinAs<T>(this FromClause source, Func<SelectQuery> builder, string alias)
+	public static T LeftJoinAs<T>(this FromClause source, Func<SelectQuery> builder, Expression<Func<T, bool>> predicate)
 	{
-		return source.LeftJoinAs<T>(builder(), alias);
+		return source.AddRelation(() => source.LeftJoin(builder()), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, string alias)
+	public static T RightJoinAs<T>(this FromClause source, Expression<Func<T, bool>> predicate)
 	{
 		var table = typeof(T).ToTableName();
-		return source.RightJoinAs<T>(table, alias);
+		return source.AddRelation(() => source.RightJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, string table, string alias)
+	public static T RightJoinAs<T>(this FromClause source, string table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.RightJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.RightJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, CommonTable table, string alias)
+	public static T RightJoinAs<T>(this FromClause source, CommonTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.RightJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.RightJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, SelectableTable table, string alias)
+	public static T RightJoinAs<T>(this FromClause source, SelectableTable table, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.RightJoin(table);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.RightJoin(table), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, IReadQuery query, string alias)
+	public static T RightJoinAs<T>(this FromClause source, IReadQuery query, Expression<Func<T, bool>> predicate)
 	{
-		var r = source.RightJoin(query);
-		var builder = new JoinBuilder<T>(source, r);
-		return builder.As(alias);
+		return source.AddRelation(() => source.RightJoin(query), predicate);
 	}
 
-	public static JoinBuilder<T> RightJoinAs<T>(this FromClause source, Func<SelectQuery> builder, string alias)
+	public static T RightJoinAs<T>(this FromClause source, Func<SelectQuery> builder, Expression<Func<T, bool>> predicate)
 	{
-		return source.RightJoinAs<T>(builder(), alias);
+		return source.AddRelation(() => source.RightJoin(builder()), predicate);
 	}
 
 	public static T CrossJoinAs<T>(this FromClause source, string alias)

--- a/test/Carbunql.Postgres.Test/Demo.cs
+++ b/test/Carbunql.Postgres.Test/Demo.cs
@@ -34,7 +34,7 @@ public class Demo
 		// Write the table join expression.
 		// Combined expressions can be written in a type-safe manner.
 		// Note: Make sure that the join destination table alias name and return value variable name are the same.
-		table_b b = from.InnerJoinAs<table_b>("b").On(b => a.a_id == b.a_id);
+		table_b b = from.InnerJoinAs<table_b>(b => a.a_id == b.a_id);
 
 		// Describe the columns to select.
 		// If you want to get all columns, use the SelectAll method

--- a/test/Carbunql.Postgres.Test/JoinTest.cs
+++ b/test/Carbunql.Postgres.Test/JoinTest.cs
@@ -20,9 +20,9 @@ public class JoinTest
 	{
 		var sq = new SelectQuery();
 		var (from, a) = sq.FromAs<RecordA>("a");
-		var b = from.InnerJoinAs<RecordB>("b").On(b => a.a_id == b.a_id && b.text == "test");
-		var c = from.LeftJoinAs<RecordC>("c").On(c => a.a_id == c.a_id);
-		var d = from.RightJoinAs<RecordC>("d").On(d => a.a_id == d.a_id);
+		var b = from.InnerJoinAs<RecordB>(b => a.a_id == b.a_id && b.text == "test");
+		var c = from.LeftJoinAs<RecordC>(c => a.a_id == c.a_id);
+		var d = from.RightJoinAs<RecordC>(d => a.a_id == d.a_id);
 		var e = from.CrossJoinAs<RecordC>("e");
 
 		sq.SelectAll();
@@ -48,7 +48,7 @@ FROM
 	{
 		var sq = new SelectQuery();
 		var (from, a) = sq.FromAs<RecordA>("a");
-		var b = from.InnerJoinAs<RecordB>("b").On(b => a.a_id == b.a_id);
+		var b = from.InnerJoinAs<RecordB>(b => a.a_id == b.a_id);
 
 		sq.SelectAll(() => b);
 
@@ -73,7 +73,7 @@ FROM
 	{
 		var sq = new SelectQuery();
 		var (from, a) = sq.FromAs<RecordA>("a");
-		var b = from.InnerJoinAs<RecordB>("INPUT_TABLE", "b").On(b => a.a_id == b.a_id);
+		var b = from.InnerJoinAs<RecordB>("INPUT_TABLE", b => a.a_id == b.a_id);
 
 		sq.SelectAll(() => b);
 
@@ -105,7 +105,7 @@ FROM
 			subq.SelectAll();
 			subq.Where(() => b.b_id <= 10);
 			return subq;
-		}, "b").On(b => a.a_id == b.a_id);
+		}, b => a.a_id == b.a_id);
 
 		sq.SelectAll(() => b);
 
@@ -137,7 +137,7 @@ FROM
 	{
 		var sq = new SelectQuery();
 		var (from, a) = sq.FromAs<RecordA>("a");
-		var b = from.LeftJoinAs<RecordB>("b").On(b => a.a_id == b.a_id);
+		var b = from.LeftJoinAs<RecordB>(b => a.a_id == b.a_id);
 
 		sq.SelectAll(() => b);
 
@@ -162,7 +162,7 @@ FROM
 	{
 		var sq = new SelectQuery();
 		var (from, a) = sq.FromAs<RecordA>("a");
-		var b = from.RightJoinAs<RecordB>("b").On(b => a.a_id == b.a_id);
+		var b = from.RightJoinAs<RecordB>(b => a.a_id == b.a_id);
 
 		sq.SelectAll(() => b);
 


### PR DESCRIPTION
The argument of the Predicate expression is interpreted as an alias name.