### PR TITLE
Supports parsing of huge union queries

### DIFF
--- a/src/Carbunql/Analysis/SelectQueryParser.cs
+++ b/src/Carbunql/Analysis/SelectQueryParser.cs
@@ -30,6 +30,22 @@ public static class SelectQueryParser
 
 	internal static SelectQuery Parse(ITokenReader r)
 	{
+		var sq = ParseMain(r);
+
+		var tokens = new string[] { "union", "union all", "except", "minus", "intersect" };
+		while (r.Peek().IsEqualNoCase(tokens))
+		{
+			var op = r.Read();
+			sq.AddOperatableValue(op, ParseMain(r));
+		}
+
+		sq.LimitClause = ParseLimitOrDefault(r);
+
+		return sq;
+	}
+
+	private static SelectQuery ParseMain(ITokenReader r)
+	{
 		var sq = new SelectQuery();
 
 		r.Read("select");
@@ -41,15 +57,6 @@ public static class SelectQueryParser
 		sq.HavingClause = ParseHavingOrDefault(r);
 		sq.WindowClause = ParseWindowOrDefault(r);
 		sq.OrderClause = ParseOrderOrDefault(r);
-
-		var tokens = new string[] { "union", "union all", "except", "minus", "intersect" };
-		if (r.Peek().IsEqualNoCase(tokens))
-		{
-			var op = r.Read();
-			sq.AddOperatableValue(op, Parse(r));
-		}
-
-		sq.LimitClause = ParseLimitOrDefault(r);
 
 		return sq;
 	}

--- a/src/Carbunql/Building/ReadQueryExtension.cs
+++ b/src/Carbunql/Building/ReadQueryExtension.cs
@@ -7,13 +7,6 @@ namespace Carbunql.Building;
 
 public static class ReadQueryExtension
 {
-	public static SelectQuery GetLast(this SelectQuery source)
-	{
-		if (source.OperatableQuery == null) return source;
-		if (source.OperatableQuery.Query is SelectQuery sq) return sq.GetLast();
-		return source;
-	}
-
 	public static (SelectQuery, CommonTable) ToCTE(this IReadQuery source, string alias)
 	{
 		var sq = new SelectQuery();
@@ -270,7 +263,7 @@ public static class ReadQueryExtension
 	public static void UnionAll(this IReadQuery source, IReadQuery query)
 	{
 		var sq = source.GetOrNewSelectQuery();
-		sq.GetLast().AddOperatableValue("union all", query);
+		sq.AddOperatableValue("union all", query);
 	}
 
 	public static void UnionAll(this IReadQuery source, Func<IReadQuery> builder)
@@ -281,7 +274,7 @@ public static class ReadQueryExtension
 	public static void Union(this IReadQuery source, IReadQuery query)
 	{
 		var sq = source.GetOrNewSelectQuery();
-		sq.GetLast().AddOperatableValue("union", query);
+		sq.AddOperatableValue("union", query);
 	}
 
 	public static void Union(this IReadQuery source, Func<IReadQuery> builder)

--- a/src/Carbunql/Clauses/WithClause.cs
+++ b/src/Carbunql/Clauses/WithClause.cs
@@ -20,38 +20,35 @@ public class WithClause : IList<CommonTable>, IQueryCommandable
 
 	public bool HasRecursiveKeyword { get; set; } = false;
 
-	public IEnumerable<Token> GetTokens(Token? parent, IList<CommonTable> commons)
+	public IEnumerable<Token> GetTokens(Token? parent, IEnumerable<CommonTable> commons)
 	{
-		if (!commons.Any() || parent != null) yield break;
+		if (parent != null) yield break;
 
-		Token? clause;
-		if (HasRecursiveKeyword)
-		{
-			clause = Token.Reserved(this, null, "with recursive");
-		}
-		else
-		{
-			clause = Token.Reserved(this, null, "with");
-		}
-		yield return clause;
-
+		Token? clause = null;
 
 		var dic = new Dictionary<string, CommonTable>();
-		var isFisrt = true;
 		foreach (var item in commons)
 		{
 			if (dic.ContainsKey(item.Alias)) continue;
 			dic.Add(item.Alias, item);
 
-			if (isFisrt)
+			if (clause == null)
 			{
-				isFisrt = false;
+				if (HasRecursiveKeyword)
+				{
+					clause = Token.Reserved(this, null, "with recursive");
+				}
+				else
+				{
+					clause = Token.Reserved(this, null, "with");
+				}
+				yield return clause;
 			}
 			else
 			{
 				yield return Token.Comma(this, clause);
 			}
-			foreach (var token in item.GetTokens(clause)) yield return token;
+			foreach (var token in item.GetTokens(clause!)) yield return token;
 		}
 	}
 

--- a/src/Carbunql/Extensions/intExtension.cs
+++ b/src/Carbunql/Extensions/intExtension.cs
@@ -1,4 +1,7 @@
-﻿namespace Carbunql.Extensions;
+﻿using Cysharp.Text;
+using System.Text;
+
+namespace Carbunql.Extensions;
 
 internal static class intExtension
 {
@@ -9,8 +12,8 @@ internal static class intExtension
 
 	public static string ToSpaceString(this int source)
 	{
-		var space = string.Empty;
-		source.ForEach(x => space += " ");
-		return space;
+		using var sb = ZString.CreateStringBuilder();
+		source.ForEach(s => sb.Append(" "));
+		return sb.ToString();
 	}
 }

--- a/src/Carbunql/ReadQuery.cs
+++ b/src/Carbunql/ReadQuery.cs
@@ -10,7 +10,7 @@ public abstract class ReadQuery : IReadQuery
 {
 	public abstract SelectClause? GetSelectClause();
 
-	public OperatableQuery? OperatableQuery { get; set; }
+	public List<OperatableQuery> OperatableQueries { get; set; } = new();
 
 	public OrderClause? OrderClause { get; set; }
 
@@ -18,8 +18,7 @@ public abstract class ReadQuery : IReadQuery
 
 	public IReadQuery AddOperatableValue(string @operator, IReadQuery query)
 	{
-		if (OperatableQuery != null) throw new InvalidOperationException();
-		OperatableQuery = new OperatableQuery(@operator, query);
+		OperatableQueries.Add(new OperatableQuery(@operator, query));
 		return query;
 	}
 
@@ -45,7 +44,7 @@ public abstract class ReadQuery : IReadQuery
 			{
 				yield return item;
 			}
-		};
+		}
 		q = GetSelectClause()?.GetParameters();
 		if (q != null)
 		{
@@ -53,7 +52,7 @@ public abstract class ReadQuery : IReadQuery
 			{
 				yield return item;
 			}
-		};
+		}
 		q = GetInnerParameters();
 		if (q != null)
 		{
@@ -61,15 +60,14 @@ public abstract class ReadQuery : IReadQuery
 			{
 				yield return item;
 			}
-		};
-		q = OperatableQuery?.GetParameters();
-		if (q != null)
+		}
+		foreach (var oq in OperatableQueries)
 		{
-			foreach (var item in q)
+			foreach (var item in oq.GetParameters())
 			{
 				yield return item;
 			}
-		};
+		}
 		q = OrderClause?.GetParameters();
 		if (q != null)
 		{
@@ -77,7 +75,7 @@ public abstract class ReadQuery : IReadQuery
 			{
 				yield return item;
 			}
-		};
+		}
 		q = LimitClause?.GetParameters();
 		if (q != null)
 		{
@@ -85,7 +83,7 @@ public abstract class ReadQuery : IReadQuery
 			{
 				yield return item;
 			}
-		};
+		}
 		foreach (var item in Parameters)
 		{
 			yield return item;
@@ -97,7 +95,10 @@ public abstract class ReadQuery : IReadQuery
 	public IEnumerable<Token> GetTokens(Token? parent)
 	{
 		foreach (var item in GetCurrentTokens(parent)) yield return item;
-		if (OperatableQuery != null) foreach (var item in OperatableQuery.GetTokens(parent)) yield return item;
+		foreach (var oq in OperatableQueries)
+		{
+			foreach (var item in oq.GetTokens(parent)) yield return item;
+		}
 		if (OrderClause != null) foreach (var item in OrderClause.GetTokens(parent)) yield return item;
 		if (LimitClause != null) foreach (var item in LimitClause.GetTokens(parent)) yield return item;
 	}

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -22,7 +22,7 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 		GroupClause = q.GroupClause;
 		HavingClause = q.HavingClause;
 		WindowClause = q.WindowClause;
-		OperatableQuery = q.OperatableQuery;
+		OperatableQueries = q.OperatableQueries;
 		OrderClause = q.OrderClause;
 		LimitClause = q.LimitClause;
 	}
@@ -52,10 +52,13 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 
 		if (parent == null && WithClause != null)
 		{
-			var lst = GetCommonTables().ToList();
+			var lst = GetCommonTables();
 			foreach (var item in WithClause.GetTokens(parent, lst)) yield return item;
 		}
 		foreach (var item in SelectClause.GetTokens(parent)) yield return item;
+
+		if (FromClause == null) yield break;
+
 		if (FromClause != null) foreach (var item in FromClause.GetTokens(parent)) yield return item;
 		if (WhereClause != null) foreach (var item in WhereClause.GetTokens(parent)) yield return item;
 		if (GroupClause != null) foreach (var item in GroupClause.GetTokens(parent)) yield return item;
@@ -181,9 +184,9 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 				yield return item;
 			}
 		}
-		if (OperatableQuery != null)
+		foreach (var oq in OperatableQueries)
 		{
-			foreach (var item in OperatableQuery.GetPhysicalTables())
+			foreach (var item in oq.GetPhysicalTables())
 			{
 				yield return item;
 			}
@@ -258,9 +261,9 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 				yield return item;
 			}
 		}
-		if (OperatableQuery != null)
+		foreach (var oq in OperatableQueries)
 		{
-			foreach (var item in OperatableQuery.GetInternalQueries())
+			foreach (var item in oq.GetInternalQueries())
 			{
 				yield return item;
 			}
@@ -349,9 +352,9 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 				yield return item;
 			}
 		}
-		if (OperatableQuery != null)
+		foreach (var oq in OperatableQueries)
 		{
-			foreach (var item in OperatableQuery.GetCommonTables())
+			foreach (var item in oq.GetCommonTables())
 			{
 				yield return item;
 			}

--- a/src/Carbunql/TokenFormatLogic.cs
+++ b/src/Carbunql/TokenFormatLogic.cs
@@ -19,7 +19,7 @@ public class TokenFormatLogic
 
 		if (token.Text.Equals(",") && token.Sender is Relation) return false;
 
-		if (token.Text.Equals("as") && token.Sender is CreateTableQuery) return true;
+		if (token.Text.IsEqualNoCase("as") && token.Sender is CreateTableQuery) return true;
 
 		if (!token.Text.IsEqualNoCase("on") && token.Sender is Relation) return true;
 		if (token.Text.IsEqualNoCase("else") || token.Text.IsEqualNoCase("when")) return true;
@@ -31,7 +31,7 @@ public class TokenFormatLogic
 			return false;
 		}
 
-		if (token.Text.Equals("where") && token.Parent == null) return true;
+		if (token.Text.IsEqualNoCase("where") && token.Parent == null) return true;
 
 		return false;
 	}
@@ -71,8 +71,8 @@ public class TokenFormatLogic
 		if (token.Parent != null && token.Parent.Sender is ValuesQuery) return false;
 		if (token.Sender is FunctionValue) return false;
 		if (token.Sender is FunctionTable) return false;
-		if (token.Text.Equals("filter")) return false;
-		if (token.Text.Equals("over")) return false;
+		if (token.Text.IsEqualNoCase("filter")) return false;
+		if (token.Text.IsEqualNoCase("over")) return false;
 
 		return true;
 	}

--- a/src/Carbunql/ValuesQuery.cs
+++ b/src/Carbunql/ValuesQuery.cs
@@ -25,7 +25,7 @@ public class ValuesQuery : ReadQuery
 	{
 		var q = ValuesQueryParser.Parse(query);
 		Rows = q.Rows;
-		OperatableQuery = q.OperatableQuery;
+		OperatableQueries = q.OperatableQueries;
 		OrderClause = q.OrderClause;
 		LimitClause = q.LimitClause;
 	}

--- a/test/Carbunql.Analysis.Test/StackOverFlowTest.cs
+++ b/test/Carbunql.Analysis.Test/StackOverFlowTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Text;
+using Xunit.Abstractions;
+
+namespace Carbunql.Analysis.Test;
+
+public class StackOverFlowTest
+{
+	private readonly ITestOutputHelper Output;
+
+	public StackOverFlowTest(ITestOutputHelper output)
+	{
+		Output = output;
+	}
+
+	[Fact]
+	public void Union_50k()
+	{
+		var sb = new StringBuilder();
+		sb.Append("select 1");
+		for (int i = 0; i < 50000; i++)
+		{
+			sb.Append(" union all select 1");
+		}
+
+		var exception = Record.Exception(() =>
+		{
+			var sq = new SelectQuery(sb.ToString());
+			sq.GetTokens();
+
+			Output.WriteLine(sq.ToText());
+		});
+
+		Assert.Null(exception);
+	}
+}


### PR DESCRIPTION
I've found that writing the model back to well-formed query characters is very slow, so I'm tuning it.

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.3296)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.202
  [Host]     : .NET 6.0.28 (6.0.2824.12007), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.28 (6.0.2824.12007), X64 RyuJIT AVX2


```

## before
|                Method |        Mean |    Error |   StdDev |
|---------------------- |------------:|---------:|---------:|
|          SqModelParse | 1,323.82 μs | 3.668 μs | 3.252 μs |
|    SqModelCommandText |    36.03 μs | 0.144 μs | 0.134 μs |
|      CarbunqlDeepCopy |   110.70 μs | 0.280 μs | 0.233 μs |
|         CarbunqlParse | 1,357.76 μs | 2.980 μs | 2.788 μs |
| CarbunqlToOneLineText |   119.22 μs | 0.291 μs | 0.272 μs |
|        CarbunqlToText |   512.18 μs | 2.084 μs | 1.949 μs |


## after
|                Method |        Mean |    Error |   StdDev |
|---------------------- |------------:|---------:|---------:|
|          SqModelParse | 1,294.06 μs | 2.401 μs | 2.128 μs |
|    SqModelCommandText |    34.99 μs | 0.121 μs | 0.114 μs |
|      CarbunqlDeepCopy |   110.15 μs | 0.281 μs | 0.219 μs |
|         CarbunqlParse | 1,324.94 μs | 1.810 μs | 1.693 μs |
| CarbunqlToOneLineText |   114.61 μs | 0.540 μs | 0.505 μs |
|        CarbunqlToText |   468.47 μs | 1.511 μs | 1.413 μs |
