### PR TITLE
Supports parsing of large value queries

### DIFF
--- a/src/Carbunql/CommandTextBuilder.cs
+++ b/src/Carbunql/CommandTextBuilder.cs
@@ -75,11 +75,6 @@ public class CommandTextBuilder
 				{
 					Logger?.Invoke($"decrement indent and line break on before : {t.Text}");
 					Level = lv;
-
-					//NOTE:
-					//Remembering indentation has a big impact on performance.
-					//Improves performance by deleting the cache of indentation levels when the indentation is no longer present.
-					if (Level == 0) IndentLevels.Clear();
 					sb.Append(GetLineBreakText());
 				}
 				else
@@ -138,7 +133,16 @@ public class CommandTextBuilder
 
 	private string GetLineBreakText()
 	{
+		//init previous token
 		PrevToken = null;
+
+		// NOTE:
+		// For performance improvement, remove unnecessary indent information
+		// However, keep one for the starting position of brackets
+		var startIndent = IndentLevels.Where(x => x.Level == Level).FirstOrDefault();
+		IndentLevels.RemoveAll(x => Level <= x.Level && x != startIndent);
+
+		//line break
 		if (!SpacerCache.ContainsKey(Level))
 		{
 			SpacerCache[Level] = (Level * 4).ToSpaceString();

--- a/test/Carbunql.Analysis.Test/StackOverFlowTest.cs
+++ b/test/Carbunql.Analysis.Test/StackOverFlowTest.cs
@@ -16,10 +16,10 @@ public class StackOverFlowTest
 	public void Union_50k()
 	{
 		var sb = new StringBuilder();
-		sb.Append("select 1");
+		sb.Append("select 1,2,3,4,5,6,7,8,9,10");
 		for (int i = 0; i < 50000; i++)
 		{
-			sb.Append(" union all select 1");
+			sb.Append(" union all select 1,2,3,4,5,6,7,8,9,10");
 		}
 
 		var exception = Record.Exception(() =>
@@ -28,6 +28,27 @@ public class StackOverFlowTest
 			sq.GetTokens();
 
 			Output.WriteLine(sq.ToText());
+		});
+
+		Assert.Null(exception);
+	}
+
+	[Fact]
+	public void Values_50k()
+	{
+		var sb = new StringBuilder();
+		sb.Append("values (1,2,3,4,5,6,7,8,9,10)");
+		for (int i = 0; i < 50000; i++)
+		{
+			sb.Append(", (1,2,3,4,5,6,7,8,9,10)");
+		}
+
+		var exception = Record.Exception(() =>
+		{
+			var vq = new ValuesQuery(sb.ToString());
+			vq.GetTokens();
+
+			Output.WriteLine(vq.ToText());
 		});
 
 		Assert.Null(exception);


### PR DESCRIPTION
Improved indent level caching.
Added support for formatted display of huge queries.

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22631.3296)
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=8.0.202
  [Host]     : .NET 6.0.28 (6.0.2824.12007), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.28 (6.0.2824.12007), X64 RyuJIT AVX2


```

### before
|                Method |        Mean |     Error |    StdDev |
|---------------------- |------------:|----------:|----------:|
|          SqModelParse | 1,313.70 μs | 12.967 μs | 12.129 μs |
|    SqModelCommandText |    35.07 μs |  0.254 μs |  0.237 μs |
|      CarbunqlDeepCopy |   110.15 μs |  0.647 μs |  0.573 μs |
|         CarbunqlParse | 1,338.75 μs |  5.366 μs |  5.019 μs |
| CarbunqlToOneLineText |   118.19 μs |  0.398 μs |  0.373 μs |
|        CarbunqlToText |   519.86 μs |  1.930 μs |  1.711 μs |

### after
|                Method |        Mean |     Error |    StdDev |
|---------------------- |------------:|----------:|----------:|
|          SqModelParse | 1,307.94 μs |  3.650 μs |  3.414 μs |
|    SqModelCommandText |    35.88 μs |  0.359 μs |  0.300 μs |
|      CarbunqlDeepCopy |   109.56 μs |  0.624 μs |  0.583 μs |
|         CarbunqlParse | 1,372.50 μs | 12.326 μs | 11.530 μs |
| CarbunqlToOneLineText |   118.16 μs |  0.722 μs |  0.676 μs |
|        CarbunqlToText |   477.57 μs |  2.537 μs |  2.373 μs |
