### PR TITLE
Improved usability (schema name, table/index existence check)

### DIFF
--- a/src/Carbunql/Clauses/IndexOnClause.cs
+++ b/src/Carbunql/Clauses/IndexOnClause.cs
@@ -22,7 +22,7 @@ public class IndexOnClause : QueryCommandCollection<SortableItem>, ITable
 		Table = t.Table;
 
 	}
-	public string? Schema { get; init; } = null;
+	public string Schema { get; init; } = null;
 
 	public string Table { get; init; }
 

--- a/src/Carbunql/Clauses/TableDefinitionClause.cs
+++ b/src/Carbunql/Clauses/TableDefinitionClause.cs
@@ -11,7 +11,7 @@ public class TableDefinitionClause : QueryCommandCollection<ITableDefinition>, I
 		Table = t.Table;
 	}
 
-	public string? Schema { get; init; }
+	public string Schema { get; init; }
 
 	public string Table { get; init; }
 

--- a/src/Carbunql/CreateIndexQuery.cs
+++ b/src/Carbunql/CreateIndexQuery.cs
@@ -13,6 +13,8 @@ public class CreateIndexQuery : IAlterIndexQuery
 
 	public bool IsUnique { get; set; } = false;
 
+	public bool HasIfNotExists { get; set; } = false;
+
 	public string? IndexName { get; init; } = null;
 
 	public IndexOnClause OnClause { get; set; }
@@ -22,7 +24,7 @@ public class CreateIndexQuery : IAlterIndexQuery
 	[IgnoreMember]
 	public CommentClause? CommentClause { get; set; }
 
-	public string? Schema => OnClause.Schema;
+	public string Schema => OnClause.Schema;
 
 	public string Table => OnClause.Table;
 
@@ -58,6 +60,12 @@ public class CreateIndexQuery : IAlterIndexQuery
 
 		var ct = GetCreateIndexToken(parent);
 		yield return ct;
+
+		if (HasIfNotExists)
+		{
+			yield return Token.Reserved(this, parent, "if not exists");
+		}
+
 		if (!string.IsNullOrEmpty(IndexName))
 		{
 			yield return new Token(this, parent, IndexName);

--- a/src/Carbunql/CreateTableQuery.cs
+++ b/src/Carbunql/CreateTableQuery.cs
@@ -28,7 +28,9 @@ public class CreateTableQuery : IQueryCommandable, ICommentable, ITable
 
 	public bool IsTemporary { get; set; } = false;
 
-	public string? Schema { get; init; } = null;
+	public bool HasIfNotExists { get; set; } = false;
+
+	public string Schema { get; init; } = string.Empty;
 
 	public string Table { get; init; }
 
@@ -100,6 +102,12 @@ public class CreateTableQuery : IQueryCommandable, ICommentable, ITable
 
 		var ct = GetCreateTableToken(parent);
 		yield return ct;
+
+		if (HasIfNotExists)
+		{
+			yield return Token.Reserved(this, parent, "if not exists");
+		}
+
 		yield return new Token(this, parent, this.GetTableFullName());
 
 		if (Query != null)

--- a/src/Carbunql/DefinitionQuerySet.cs
+++ b/src/Carbunql/DefinitionQuerySet.cs
@@ -38,7 +38,7 @@ public class DefinitionQuerySet : ITable
 		CreateTableQuery = createTableQuery;
 	}
 
-	public string? Schema { get; init; }
+	public string Schema { get; init; } = string.Empty;
 
 	public string Table { get; init; }
 
@@ -375,7 +375,7 @@ public class DefinitionQuerySet : ITable
 		}
 	}
 
-	public string ToText(bool includeDropTableQuery)
+	public string ToText(bool includeDropTableQuery = false)
 	{
 		var sb = ZString.CreateStringBuilder();
 

--- a/src/Carbunql/Definitions/ITable.cs
+++ b/src/Carbunql/Definitions/ITable.cs
@@ -2,7 +2,7 @@
 
 public interface ITable
 {
-	string? Schema { get; }
+	string Schema { get; }
 
 	string Table { get; }
 }

--- a/src/Carbunql/Definitions/PrimaryKeyConstraint.cs
+++ b/src/Carbunql/Definitions/PrimaryKeyConstraint.cs
@@ -6,6 +6,12 @@ namespace Carbunql.Definitions;
 
 public class PrimaryKeyConstraint : IConstraint
 {
+	public PrimaryKeyConstraint(string schema, string table)
+	{
+		Schema = schema;
+		Table = table;
+	}
+
 	public PrimaryKeyConstraint(ITable t)
 	{
 		Schema = t.Schema;

--- a/src/Carbunql/DropTableQuery.cs
+++ b/src/Carbunql/DropTableQuery.cs
@@ -17,7 +17,9 @@ public class DropTableQuery : IQueryCommandable, ICommentable, ITable
 	[IgnoreMember]
 	public CommentClause? CommentClause { get; set; }
 
-	public string? Schema { get; init; }
+	public bool HasIfExists { get; set; } = false;
+
+	public string Schema { get; init; }
 
 	public string Table { get; init; }
 
@@ -41,6 +43,11 @@ public class DropTableQuery : IQueryCommandable, ICommentable, ITable
 		if (CommentClause != null) foreach (var item in CommentClause.GetTokens(parent)) yield return item;
 
 		yield return Token.Reserved(this, parent, "drop table");
+		if (HasIfExists)
+		{
+			yield return Token.Reserved(this, parent, "if exists");
+		}
+
 		yield return new Token(this, parent, this.GetTableFullName());
 	}
 


### PR DESCRIPTION
Schema name cannot be null. If the schema name is not required, please specify string.Empty.
You can now specify whether to check for existence when creating a table or index. (HasIfNotExists property)
You can now specify whether to check for the existence of a table when dropping it. (HasIfExists property)