### PR TITLE
Supports insert query analysis

### DIFF
--- a/src/Carbunql/Analysis/InsertQueryParser.cs
+++ b/src/Carbunql/Analysis/InsertQueryParser.cs
@@ -1,0 +1,64 @@
+﻿using Carbunql.Analysis.Parser;
+using Carbunql.Building;
+using Carbunql.Extensions;
+
+namespace Carbunql.Analysis;
+
+public static class InsertQueryParser
+{
+	public static InsertQuery Parse(string text)
+	{
+		var r = new SqlTokenReader(text);
+
+		var iq = Parse(r);
+
+		if (!r.Peek().IsEndToken())
+		{
+			throw new NotSupportedException($"Parsing terminated despite the presence of unparsed tokens.(token:'{r.Peek()}')");
+		}
+
+		return iq;
+	}
+
+	internal static InsertQuery Parse(ITokenReader r)
+	{
+		if (r.Peek().IsEqualNoCase("with"))
+		{
+			// NOTE
+			// Although this is a preliminary specification,
+			// insert queries themselves do not allow CTEs.
+			// So if her CTE is mentioned in the insert query,
+			// it will be forced to be treated as her CTE in the select query.
+			var withClause = WithClauseParser.Parse(r);
+			var iq = ParseMain(r);
+			if (iq.Query is SelectQuery sq)
+			{
+				foreach (var item in withClause)
+				{
+					sq.With(item);
+				}
+			}
+			return iq;
+		}
+		else
+		{
+			return ParseMain(r);
+		}
+		throw new NotSupportedException();
+	}
+
+	internal static InsertQuery ParseMain(ITokenReader r)
+	{
+		var iq = new InsertQuery();
+
+		iq.InsertClause = InsertClauseParser.Parse(r);
+		iq.Query = QueryParser.Parse(r);
+
+		if (r.Peek().IsEqualNoCase("returning"))
+		{
+			iq.ReturningClause = ReturningClauseParser.Parse(r);
+		}
+
+		return iq;
+	}
+}

--- a/src/Carbunql/Analysis/Parser/InsertClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/InsertClauseParser.cs
@@ -1,0 +1,18 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class InsertClauseParser
+{
+	public static InsertClause Parse(string text)
+	{
+		var r = new SqlTokenReader(text);
+		return Parse(r);
+	}
+
+	public static InsertClause Parse(ITokenReader r)
+	{
+		r.Read("insert into");
+		return new InsertClause(SelectableTableParser.Parse(r));
+	}
+}

--- a/src/Carbunql/Analysis/Parser/ReturningClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/ReturningClauseParser.cs
@@ -1,0 +1,29 @@
+﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class ReturningClauseParser
+{
+	public static ReturningClause Parse(string text)
+	{
+		var r = new SqlTokenReader(text);
+		return Parse(r);
+	}
+
+	public static ReturningClause Parse(ITokenReader r)
+	{
+		r.ReadOrDefault("returning");
+		return new ReturningClause(ParseItems(r).ToList());
+	}
+
+	private static IEnumerable<ValueBase> ParseItems(ITokenReader r)
+	{
+		do
+		{
+			if (r.Peek().IsEqualNoCase(",")) r.Read();
+			yield return ValueParser.Parse(r);
+		}
+		while (r.Peek().IsEqualNoCase(","));
+	}
+}

--- a/src/Carbunql/Analysis/TokenReader.cs
+++ b/src/Carbunql/Analysis/TokenReader.cs
@@ -215,6 +215,16 @@ public abstract class TokenReader
 			return sb.ToString();
 		}
 
+		if (lex.IsEqualNoCase(new[] { "insert" }))
+		{
+			if (Reader.TryRead("into", out var into))
+			{
+				//insert into
+				sb.Append(" " + into);
+				return sb.ToString();
+			}
+			return sb.ToString();
+		}
 		//if (lex.IsEqualNoCase("generated"))
 		//{
 		//	if (Reader.TryRead("always", out var always))

--- a/src/Carbunql/Clauses/ReturningClause.cs
+++ b/src/Carbunql/Clauses/ReturningClause.cs
@@ -1,49 +1,52 @@
 ﻿using Carbunql.Tables;
+using Carbunql.Values;
 
 namespace Carbunql.Clauses;
 
-public class ReturningClause : IQueryCommandable
+public class ReturningClause : QueryCommandCollection<ValueBase>, IQueryCommandable
 {
 	public ReturningClause(ValueBase value)
 	{
-		Value = value;
+		if (value is ValueCollection collection)
+		{
+			foreach (var item in collection)
+			{
+				Items.Add(item);
+			}
+		}
+		else
+		{
+			Items.Add(value);
+		}
 	}
 
-	public ValueBase Value { get; init; }
+	public ReturningClause(IEnumerable<ValueBase> values)
+	{
+		foreach (var item in values)
+		{
+			Items.Add(item);
+		}
+	}
 
-	public IEnumerable<Token> GetTokens(Token? parent)
+	public override IEnumerable<Token> GetTokens(Token? parent)
 	{
 		var t = Token.Reserved(this, parent, "returning");
 		yield return t;
-		foreach (var item in Value.GetTokens(t)) yield return item;
+		foreach (var item in base.GetTokens(t)) yield return item;
 	}
 
 	public IEnumerable<SelectQuery> GetInternalQueries()
 	{
-		foreach (var item in Value.GetInternalQueries())
-		{
-			yield return item;
-		}
+		yield break;
 	}
 
 	public IEnumerable<PhysicalTable> GetPhysicalTables()
 	{
-		foreach (var item in Value.GetPhysicalTables())
-		{
-			yield return item;
-		}
-	}
-
-	public IEnumerable<QueryParameter> GetParameters()
-	{
-		return Value.GetParameters();
+		yield break;
 	}
 
 	public IEnumerable<CommonTable> GetCommonTables()
 	{
-		foreach (var item in Value.GetCommonTables())
-		{
-			yield return item;
-		}
+		yield break;
 	}
 }

--- a/test/Carbunql.Analysis.Test/InsertQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/InsertQueryParserTest.cs
@@ -1,0 +1,221 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.Analysis.Test;
+
+public class InsertQueryParserTest
+{
+	private readonly QueryCommandMonitor Monitor;
+
+	public InsertQueryParserTest(ITestOutputHelper output)
+	{
+		Monitor = new QueryCommandMonitor(output);
+	}
+
+	[Fact]
+	public void InsertValues()
+	{
+		var text = @"
+INSERT INTO sale (sale_date,price,created_at) VALUES
+     ('2023-01-01',160,'2024-01-11 14:29:01.618'),
+     ('2023-03-12',200,'2024-01-11 14:29:01.618')";
+
+		var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+VALUES
+    ('2023-01-01', 160, '2024-01-11 14:29:01.618'),
+    ('2023-03-12', 200, '2024-01-11 14:29:01.618')";
+
+		var iq = InsertQueryParser.Parse(text);
+		if (iq == null) throw new Exception();
+
+		Monitor.Log(iq);
+
+		var lst = iq.GetTokens().ToList();
+
+		Assert.Equal(25, lst.Count);
+		Assert.Equal(expect, iq.ToText(), true, true, true);
+	}
+
+	[Fact]
+	public void InsertSelect()
+	{
+		var text = @"
+INSERT INTO sale (sale_date,price,created_at)
+select
+'2023-01-01' as sale_date,
+160 as price,
+'2024-01-11 14:29:01.618' as created_at
+union all
+select
+'2023-03-12' as sale_date,
+200 as price,
+'2024-01-11 14:29:01.618' as created_at";
+
+		var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+SELECT
+    '2023-01-01' AS sale_date,
+    160 AS price,
+    '2024-01-11 14:29:01.618' AS created_at
+UNION ALL
+SELECT
+    '2023-03-12' AS sale_date,
+    200 AS price,
+    '2024-01-11 14:29:01.618' AS created_at";
+
+		var iq = InsertQueryParser.Parse(text);
+		if (iq == null) throw new Exception();
+
+		Monitor.Log(iq);
+
+		var lst = iq.GetTokens().ToList();
+
+		Assert.Equal(34, lst.Count);
+		Assert.Equal(expect, iq.ToText(), true, true, true);
+	}
+
+	[Fact]
+	public void InsertValuesReturning()
+	{
+		var text = @"
+INSERT INTO sale (sale_date,price,created_at) VALUES
+     ('2023-01-01',160,'2024-01-11 14:29:01.618'),
+     ('2023-03-12',200,'2024-01-11 14:29:01.618')
+returning sale_id, sale_date, price, created_at";
+
+		var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+VALUES
+    ('2023-01-01', 160, '2024-01-11 14:29:01.618'),
+    ('2023-03-12', 200, '2024-01-11 14:29:01.618')
+RETURNING
+    sale_id, sale_date, price, created_at";
+
+		var iq = InsertQueryParser.Parse(text);
+		if (iq == null) throw new Exception();
+
+		Monitor.Log(iq);
+
+		var lst = iq.GetTokens().ToList();
+
+		Assert.Equal(33, lst.Count);
+		Assert.Equal(expect, iq.ToText(), true, true, true);
+	}
+
+	[Fact]
+	public void InsertWithSelect()
+	{
+		var text = @"
+INSERT INTO sale (sale_date,price,created_at)
+with
+dat as (
+	select
+	'2023-01-01' as sale_date,
+	160 as price,
+	'2024-01-11 14:29:01.618' as created_at
+	union all
+	select
+	'2023-03-12' as sale_date,
+	200 as price,
+	'2024-01-11 14:29:01.618' as created_at
+)
+select
+sale_date,price,created_at
+from
+dat
+"
+;
+
+		var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+WITH
+    dat AS (
+        SELECT
+            '2023-01-01' AS sale_date,
+            160 AS price,
+            '2024-01-11 14:29:01.618' AS created_at
+        UNION ALL
+        SELECT
+            '2023-03-12' AS sale_date,
+            200 AS price,
+            '2024-01-11 14:29:01.618' AS created_at
+    )
+SELECT
+    sale_date,
+    price,
+    created_at
+FROM
+    dat";
+
+		var iq = InsertQueryParser.Parse(text);
+		if (iq == null) throw new Exception();
+
+		Monitor.Log(iq);
+
+		var lst = iq.GetTokens().ToList();
+
+		Assert.Equal(47, lst.Count);
+		Assert.Equal(expect, iq.ToText(), true, true, true);
+	}
+
+	[Fact]
+	public void WithInsertSelect()
+	{
+		var text = @"
+with
+dat as (
+	select
+	'2023-01-01' as sale_date,
+	160 as price,
+	'2024-01-11 14:29:01.618' as created_at
+	union all
+	select
+	'2023-03-12' as sale_date,
+	200 as price,
+	'2024-01-11 14:29:01.618' as created_at
+)
+INSERT INTO sale (sale_date,price,created_at)
+select
+sale_date,price,created_at
+from
+dat
+"
+;
+
+		// NOTE
+		// Although this is a preliminary specification,
+		// insert queries themselves do not allow CTEs.
+		// So if her CTE is mentioned in the insert query,
+		// it will be forced to be treated as her CTE in the select query.
+		var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+WITH
+    dat AS (
+        SELECT
+            '2023-01-01' AS sale_date,
+            160 AS price,
+            '2024-01-11 14:29:01.618' AS created_at
+        UNION ALL
+        SELECT
+            '2023-03-12' AS sale_date,
+            200 AS price,
+            '2024-01-11 14:29:01.618' AS created_at
+    )
+SELECT
+    sale_date,
+    price,
+    created_at
+FROM
+    dat";
+
+		var iq = InsertQueryParser.Parse(text);
+		if (iq == null) throw new Exception();
+
+		Monitor.Log(iq);
+
+		var lst = iq.GetTokens().ToList();
+
+		Assert.Equal(47, lst.Count);
+		Assert.Equal(expect, iq.ToText(), true, true, true);
+	}
+}


### PR DESCRIPTION
Changed the structure of the ReturningClause class.

NOTE:
Although this is a preliminary specification, insert queries themselves do not allow CTEs. So if her CTE is mentioned in the insert query, it will be forced to be treated as her CTE in the select query.