### PR TITLE
Added QueryCommandableParser class

### DIFF
--- a/demo/CarbunqlWeb/Pages/Format.razor
+++ b/demo/CarbunqlWeb/Pages/Format.razor
@@ -17,7 +17,7 @@
         <div class="col-md-12 p-3">
             <RadzenText TextStyle="TextStyle.H4">Format</RadzenText>
 
-            <RadzenText>SQL can be formatted.</RadzenText>
+            <RadzenText>SQL can be formatted.Åiselect, values, insert, create table, create index, alter tableÅj</RadzenText>
             
              <RadzenCard>
                 <RadzenText TextStyle="TextStyle.Subtitle2">Source code</RadzenText>
@@ -51,8 +51,8 @@
 
     string sourcecode = @"using Carbunql;
 
-var sq = new SelectQuery(""select id, val from table_a as a"");
-Console.WriteLine(sq.ToCommand().CommandText);";
+var q = QueryCommandableParser.Parse(sql_text);
+Console.WriteLine(q.ToText());";
 
     protected override void OnInitialized()
 	{
@@ -74,8 +74,8 @@ Console.WriteLine(sq.ToCommand().CommandText);";
 		}
 		try
 		{
-			var sq = QueryParser.Parse(sql);
-			fsql = sq.ToCommand().CommandText;
+            var q = QueryCommandableParser.Parse(sql);
+			fsql = q.ToText();
 		}
 		catch (Exception ex)
 		{

--- a/src/Carbunql/Analysis/QueryCommandableParser.cs
+++ b/src/Carbunql/Analysis/QueryCommandableParser.cs
@@ -1,0 +1,72 @@
+﻿using Carbunql.Analysis.Parser;
+using Carbunql.Building;
+using Carbunql.Extensions;
+
+namespace Carbunql.Analysis;
+
+public static class QueryCommandableParser
+{
+	public static IQueryCommandable Parse(string text)
+	{
+		var r = new SqlTokenReader(text);
+		var q = Parse(r);
+
+		if (!r.Peek().IsEndToken())
+		{
+			throw new NotSupportedException($"Parsing terminated despite the presence of unparsed tokens.(token:'{r.Peek()}')");
+		}
+
+		return q;
+	}
+
+	public static IQueryCommandable Parse(ITokenReader r)
+	{
+		var token = r.Peek();
+
+		if (token.IsEqualNoCase("with"))
+		{
+			var clause = WithClauseParser.Parse(r);
+
+			token = r.Peek();
+			if (token.IsEqualNoCase("select"))
+			{
+				var sq = SelectQueryParser.Parse(r);
+				sq.WithClause = clause;
+				return sq;
+			}
+			else if (token.IsEqualNoCase("insert into"))
+			{
+				// NOTE
+				// Although this is a preliminary specification,
+				// insert queries themselves do not allow CTEs.
+				// So if her CTE is mentioned in the insert query,
+				// it will be forced to be treated as her CTE in the select query.
+				var iq = InsertQueryParser.Parse(r);
+				if (iq.Query is SelectQuery sq)
+				{
+					foreach (var item in clause)
+					{
+						sq.With(item);
+					}
+				}
+				return iq;
+			}
+
+			throw new NotSupportedException();
+		}
+		else
+		{
+			if (token.IsEqualNoCase("select")) return SelectQueryParser.Parse(r);
+			if (token.IsEqualNoCase("values")) return ValuesQueryParser.Parse(r);
+
+			if (token.IsEqualNoCase("insert into")) return InsertQueryParser.Parse(r);
+
+			if (token.IsEqualNoCase("create table")) return CreateTableQueryParser.Parse(r);
+			if (token.IsEqualNoCase("create index")) return CreateIndexQueryParser.Parse(r);
+
+			if (token.IsEqualNoCase("alter table")) return AlterTableQueryParser.Parse(r);
+
+			throw new NotSupportedException();
+		}
+	}
+}


### PR DESCRIPTION
You can parse queries (selects, values, create tables, inserts, etc.) that inherit from QueryCommandable. It is possible to properly parse even if the query type of the input value is unknown.