### PR TITLE
Enhanced parsing and conversion functions for Insert queries

### DIFF
--- a/src/Carbunql/Analysis/QueryParser.cs
+++ b/src/Carbunql/Analysis/QueryParser.cs
@@ -5,26 +5,26 @@ namespace Carbunql.Analysis;
 
 public static class QueryParser
 {
-	public static IReadQuery Parse(string text)
-	{
-		var r = new SqlTokenReader(text);
-		var q = Parse(r);
+    public static IReadQuery Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        var q = Parse(r);
 
-		if (!r.Peek().IsEndToken())
-		{
-			throw new NotSupportedException($"Parsing terminated despite the presence of unparsed tokens.(token:'{r.Peek()}')");
-		}
+        if (!r.Peek().IsEndToken())
+        {
+            throw new NotSupportedException($"Parsing terminated despite the presence of unparsed tokens.(token:'{r.Peek()}')");
+        }
 
-		return q;
-	}
+        return q;
+    }
 
-	public static IReadQuery Parse(ITokenReader r)
-	{
-		var token = r.Peek();
-		if (token.IsEqualNoCase("with")) return CTEQueryParser.Parse(r);
-		if (token.IsEqualNoCase("select")) return SelectQueryParser.Parse(r);
-		if (token.IsEqualNoCase("values")) return ValuesQueryParser.Parse(r);
+    public static IReadQuery Parse(ITokenReader r)
+    {
+        var token = r.Peek();
+        if (token.IsEqualNoCase("with")) return CTEQueryParser.Parse(r);
+        if (token.IsEqualNoCase("select")) return SelectQueryParser.Parse(r);
+        if (token.IsEqualNoCase("values")) return ValuesQueryParser.Parse(r);
 
-		throw new NotSupportedException();
-	}
+        throw new NotSupportedException($"Token:{r.Peek()}");
+    }
 }

--- a/src/Carbunql/Clauses/ValueBase.cs
+++ b/src/Carbunql/Clauses/ValueBase.cs
@@ -23,142 +23,142 @@ namespace Carbunql.Clauses;
 [Union(13, typeof(ValueCollection))]
 public abstract class ValueBase : IQueryCommandable
 {
-	public virtual string GetDefaultName() => string.Empty;
+    public virtual string GetDefaultName() => string.Empty;
 
-	public OperatableValue? OperatableValue { get; set; }
+    public OperatableValue? OperatableValue { get; set; }
 
-	public ValueBase AddOperatableValue(string @operator, ValueBase value)
-	{
-		//if (OperatableValue != null) throw new InvalidOperationException();
-		if (OperatableValue != null)
-		{
-			OperatableValue.Value.AddOperatableValue(@operator, value);
-			return this;
-		}
-		OperatableValue = new OperatableValue(@operator, value);
-		return this;
-	}
+    public ValueBase AddOperatableValue(string @operator, ValueBase value)
+    {
+        //if (OperatableValue != null) throw new InvalidOperationException();
+        if (OperatableValue != null)
+        {
+            OperatableValue.Value.AddOperatableValue(@operator, value);
+            return this;
+        }
+        OperatableValue = new OperatableValue(@operator, value);
+        return this;
+    }
 
-	public string RecommendedName { get; set; } = string.Empty;
+    public string RecommendedName { get; set; } = string.Empty;
 
-	public ValueBase AddOperatableValue(string @operator, string value)
-	{
-		return AddOperatableValue(@operator, ValueParser.Parse(value));
-	}
+    public ValueBase AddOperatableValue(string @operator, string value)
+    {
+        return AddOperatableValue(@operator, ValueParser.Parse(value));
+    }
 
-	public IEnumerable<string> GetOperators()
-	{
-		if (OperatableValue == null) yield break;
-		yield return OperatableValue.Operator;
-		foreach (var item in OperatableValue.Value.GetOperators()) yield return item;
-	}
+    public IEnumerable<string> GetOperators()
+    {
+        if (OperatableValue == null) yield break;
+        yield return OperatableValue.Operator;
+        foreach (var item in OperatableValue.Value.GetOperators()) yield return item;
+    }
 
-	public virtual IEnumerable<QueryParameter> GetParameters()
-	{
-		foreach (var item in GetParametersCore())
-		{
-			yield return item;
-		};
-		var q = OperatableValue?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-	}
+    public virtual IEnumerable<QueryParameter> GetParameters()
+    {
+        foreach (var item in GetParametersCore())
+        {
+            yield return item;
+        };
+        var q = OperatableValue?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<SelectQuery> GetInternalQueries()
-	{
-		foreach (var item in GetInternalQueriesCore())
-		{
-			yield return item;
-		}
-		if (OperatableValue != null)
-		{
-			foreach (var item in OperatableValue.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        foreach (var item in GetInternalQueriesCore())
+        {
+            yield return item;
+        }
+        if (OperatableValue != null)
+        {
+            foreach (var item in OperatableValue.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<PhysicalTable> GetPhysicalTables()
-	{
-		foreach (var item in GetPhysicalTablesCore())
-		{
-			yield return item;
-		}
-		if (OperatableValue != null)
-		{
-			foreach (var item in OperatableValue.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        foreach (var item in GetPhysicalTablesCore())
+        {
+            yield return item;
+        }
+        if (OperatableValue != null)
+        {
+            foreach (var item in OperatableValue.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<CommonTable> GetCommonTables()
-	{
-		foreach (var item in GetCommonTablesCore())
-		{
-			yield return item;
-		}
-		if (OperatableValue != null)
-		{
-			foreach (var item in OperatableValue.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<CommonTable> GetCommonTables()
+    {
+        foreach (var item in GetCommonTablesCore())
+        {
+            yield return item;
+        }
+        if (OperatableValue != null)
+        {
+            foreach (var item in OperatableValue.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<ValueBase> GetValues()
-	{
-		yield return this;
+    public virtual IEnumerable<ValueBase> GetValues()
+    {
+        yield return this;
 
-		if (OperatableValue != null)
-		{
-			foreach (var item in OperatableValue.Value.GetValues())
-			{
-				yield return item;
-			}
-		}
-	}
+        if (OperatableValue != null)
+        {
+            foreach (var item in OperatableValue.Value.GetValues())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	protected abstract IEnumerable<QueryParameter> GetParametersCore();
+    protected abstract IEnumerable<QueryParameter> GetParametersCore();
 
-	protected abstract IEnumerable<SelectQuery> GetInternalQueriesCore();
+    protected abstract IEnumerable<SelectQuery> GetInternalQueriesCore();
 
-	protected abstract IEnumerable<PhysicalTable> GetPhysicalTablesCore();
+    protected abstract IEnumerable<PhysicalTable> GetPhysicalTablesCore();
 
-	protected abstract IEnumerable<CommonTable> GetCommonTablesCore();
+    protected abstract IEnumerable<CommonTable> GetCommonTablesCore();
 
-	public abstract IEnumerable<Token> GetCurrentTokens(Token? parent);
+    public abstract IEnumerable<Token> GetCurrentTokens(Token? parent);
 
-	public IEnumerable<Token> GetTokens(Token? parent)
-	{
-		foreach (var item in GetCurrentTokens(parent)) yield return item;
+    public IEnumerable<Token> GetTokens(Token? parent)
+    {
+        foreach (var item in GetCurrentTokens(parent)) yield return item;
 
-		if (OperatableValue != null)
-		{
-			foreach (var item in OperatableValue.GetTokens(parent)) yield return item;
-		}
-	}
+        if (OperatableValue != null)
+        {
+            foreach (var item in OperatableValue.GetTokens(parent)) yield return item;
+        }
+    }
 
-	public BracketValue ToBracket()
-	{
-		return new BracketValue(this);
-	}
+    public BracketValue ToBracket()
+    {
+        return new BracketValue(this);
+    }
 
-	public WhereClause ToWhereClause()
-	{
-		return new WhereClause(this);
-	}
+    public WhereClause ToWhereClause()
+    {
+        return new WhereClause(this);
+    }
 
-	public string ToText()
-	{
-		return GetTokens(null).ToText();
-	}
+    public string ToText()
+    {
+        return GetTokens(null).ToText();
+    }
 }

--- a/src/Carbunql/InsertQuery.cs
+++ b/src/Carbunql/InsertQuery.cs
@@ -2,77 +2,110 @@
 using Carbunql.Clauses;
 using Carbunql.Tables;
 using MessagePack;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Carbunql;
 
 public class InsertQuery : IQueryCommandable, IReturning, ICommentable
 {
-	public InsertClause? InsertClause { get; set; }
+    public InsertClause? InsertClause { get; set; }
 
-	public ReturningClause? ReturningClause { get; set; }
+    public ReturningClause? ReturningClause { get; set; }
 
-	[IgnoreMember]
-	public CommentClause? CommentClause { get; set; }
+    [IgnoreMember]
+    public CommentClause? CommentClause { get; set; }
 
-	public IReadQuery? Query { get; set; }
+    public IReadQuery? Query { get; set; }
 
-	public IEnumerable<SelectQuery> GetInternalQueries()
-	{
-		if (Query != null)
-		{
-			foreach (var item in Query.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        if (Query != null)
+        {
+            foreach (var item in Query.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<PhysicalTable> GetPhysicalTables()
-	{
-		if (Query != null)
-		{
-			foreach (var item in Query.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        if (Query != null)
+        {
+            foreach (var item in Query.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<CommonTable> GetCommonTables()
-	{
-		if (Query != null)
-		{
-			foreach (var item in Query.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<CommonTable> GetCommonTables()
+    {
+        if (Query != null)
+        {
+            foreach (var item in Query.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<QueryParameter>? Parameters { get; set; }
+    public IEnumerable<QueryParameter>? Parameters { get; set; }
 
-	public virtual IEnumerable<QueryParameter> GetParameters()
-	{
-		if (Parameters != null)
-		{
-			foreach (var item in Parameters)
-			{
-				yield return item;
-			}
-		}
-	}
+    public virtual IEnumerable<QueryParameter> GetParameters()
+    {
+        if (Parameters != null)
+        {
+            foreach (var item in Parameters)
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<Token> GetTokens(Token? parent)
-	{
-		if (Query == null) throw new NullReferenceException(nameof(Query));
-		if (InsertClause == null) throw new NullReferenceException(nameof(InsertClause));
+    public IEnumerable<Token> GetTokens(Token? parent)
+    {
+        if (Query == null) throw new NullReferenceException(nameof(Query));
+        if (InsertClause == null) throw new NullReferenceException(nameof(InsertClause));
 
-		if (CommentClause != null) foreach (var item in CommentClause.GetTokens(parent)) yield return item;
+        if (CommentClause != null) foreach (var item in CommentClause.GetTokens(parent)) yield return item;
 
-		foreach (var item in InsertClause.GetTokens(parent)) yield return item;
-		foreach (var item in Query.GetTokens(parent)) yield return item;
+        foreach (var item in InsertClause.GetTokens(parent)) yield return item;
+        foreach (var item in Query.GetTokens(parent)) yield return item;
 
-		if (ReturningClause == null) yield break;
-		foreach (var item in ReturningClause.GetTokens(parent)) yield return item;
-	}
+        if (ReturningClause == null) yield break;
+        foreach (var item in ReturningClause.GetTokens(parent)) yield return item;
+    }
+
+    public bool TryConvertToInsertSelect([MaybeNullWhen(false)] out InsertQuery insertQuery)
+    {
+        insertQuery = default;
+        if (Query is ValuesQuery v && InsertClause != null && InsertClause.Table.Table is FunctionTable ft)
+        {
+            var names = ft.Argument.GetValues().Select(x => x.ToText()).ToList();
+            var iq = new InsertQuery();
+            iq.InsertClause = InsertClause;
+            iq.Query = v.ToPlainSelectQuery(names);
+            insertQuery = iq;
+            return true;
+        }
+        return false;
+    }
+
+    public bool TryConvertToInsertValues([MaybeNullWhen(false)] out InsertQuery insertQuery)
+    {
+        insertQuery = default;
+        if (Query is SelectQuery sq && sq.FromClause is null && sq.SelectClause is not null)
+        {
+            if (sq.TryToValuesQuery(out var values))
+            {
+                var iq = new InsertQuery();
+                iq.InsertClause = InsertClause;
+                iq.Query = values;
+                insertQuery = iq;
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -3,375 +3,415 @@ using Carbunql.Building;
 using Carbunql.Clauses;
 using Carbunql.Extensions;
 using Carbunql.Tables;
+using Carbunql.Values;
 using MessagePack;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Carbunql;
 
 [MessagePackObject(keyAsPropertyName: true)]
 public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 {
-	public SelectQuery() { }
+    public SelectQuery() { }
 
-	public SelectQuery(string query)
-	{
-		var q = SelectQueryParser.Parse(query);
-		WithClause = q.WithClause;
-		SelectClause = q.SelectClause;
-		FromClause = q.FromClause;
-		WhereClause = q.WhereClause;
-		GroupClause = q.GroupClause;
-		HavingClause = q.HavingClause;
-		WindowClause = q.WindowClause;
-		OperatableQueries = q.OperatableQueries;
-		OrderClause = q.OrderClause;
-		LimitClause = q.LimitClause;
-	}
+    public SelectQuery(string query)
+    {
+        var q = SelectQueryParser.Parse(query);
+        WithClause = q.WithClause;
+        SelectClause = q.SelectClause;
+        FromClause = q.FromClause;
+        WhereClause = q.WhereClause;
+        GroupClause = q.GroupClause;
+        HavingClause = q.HavingClause;
+        WindowClause = q.WindowClause;
+        OperatableQueries = q.OperatableQueries;
+        OrderClause = q.OrderClause;
+        LimitClause = q.LimitClause;
+    }
 
-	public WithClause? WithClause { get; set; } = new();
+    public WithClause? WithClause { get; set; } = new();
 
-	public SelectClause? SelectClause { get; set; }
+    public SelectClause? SelectClause { get; set; }
 
-	public FromClause? FromClause { get; set; }
+    public FromClause? FromClause { get; set; }
 
-	public WhereClause? WhereClause { get; set; }
+    public WhereClause? WhereClause { get; set; }
 
-	public GroupClause? GroupClause { get; set; }
+    public GroupClause? GroupClause { get; set; }
 
-	public HavingClause? HavingClause { get; set; }
+    public HavingClause? HavingClause { get; set; }
 
-	public WindowClause? WindowClause { get; set; }
+    public WindowClause? WindowClause { get; set; }
 
-	[IgnoreMember]
-	public CommentClause? CommentClause { get; set; }
+    [IgnoreMember]
+    public CommentClause? CommentClause { get; set; }
 
-	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
-	{
-		if (CommentClause != null) foreach (var item in CommentClause.GetTokens(parent)) yield return item;
+    public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+    {
+        if (CommentClause != null) foreach (var item in CommentClause.GetTokens(parent)) yield return item;
 
-		if (SelectClause == null) yield break;
+        if (SelectClause == null) yield break;
 
-		if (parent == null && WithClause != null)
-		{
-			var lst = GetCommonTables();
-			foreach (var item in WithClause.GetTokens(parent, lst)) yield return item;
-		}
-		foreach (var item in SelectClause.GetTokens(parent)) yield return item;
+        if (parent == null && WithClause != null)
+        {
+            var lst = GetCommonTables();
+            foreach (var item in WithClause.GetTokens(parent, lst)) yield return item;
+        }
+        foreach (var item in SelectClause.GetTokens(parent)) yield return item;
 
-		if (FromClause == null) yield break;
+        if (FromClause == null) yield break;
 
-		if (FromClause != null) foreach (var item in FromClause.GetTokens(parent)) yield return item;
-		if (WhereClause != null) foreach (var item in WhereClause.GetTokens(parent)) yield return item;
-		if (GroupClause != null) foreach (var item in GroupClause.GetTokens(parent)) yield return item;
-		if (HavingClause != null) foreach (var item in HavingClause.GetTokens(parent)) yield return item;
-		if (WindowClause != null) foreach (var item in WindowClause.GetTokens(parent)) yield return item;
-	}
+        if (FromClause != null) foreach (var item in FromClause.GetTokens(parent)) yield return item;
+        if (WhereClause != null) foreach (var item in WhereClause.GetTokens(parent)) yield return item;
+        if (GroupClause != null) foreach (var item in GroupClause.GetTokens(parent)) yield return item;
+        if (HavingClause != null) foreach (var item in HavingClause.GetTokens(parent)) yield return item;
+        if (WindowClause != null) foreach (var item in WindowClause.GetTokens(parent)) yield return item;
+    }
 
-	public override WithClause? GetWithClause() => WithClause;
+    public override WithClause? GetWithClause() => WithClause;
 
-	public override SelectClause? GetSelectClause() => SelectClause;
+    public override SelectClause? GetSelectClause() => SelectClause;
 
-	public override SelectQuery GetOrNewSelectQuery() => this;
+    public override SelectQuery GetOrNewSelectQuery() => this;
 
-	public override IEnumerable<QueryParameter> GetInnerParameters()
-	{
-		var q = FromClause?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-		q = WhereClause?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-		q = GroupClause?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-		q = HavingClause?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-		q = WindowClause?.GetParameters();
-		if (q != null)
-		{
-			foreach (var item in q)
-			{
-				yield return item;
-			}
-		}
-	}
+    public override IEnumerable<QueryParameter> GetInnerParameters()
+    {
+        var q = FromClause?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+        q = WhereClause?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+        q = GroupClause?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+        q = HavingClause?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+        q = WindowClause?.GetParameters();
+        if (q != null)
+        {
+            foreach (var item in q)
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
-	{
-		var vt = new VirtualTable(this);
-		if (columnAliases != null)
-		{
-			return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
-		}
-		return new SelectableTable(vt, "q");
-	}
+    public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
+    {
+        var vt = new VirtualTable(this);
+        if (columnAliases != null)
+        {
+            return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
+        }
+        return new SelectableTable(vt, "q");
+    }
 
-	public override IEnumerable<string> GetColumnNames()
-	{
-		if (SelectClause == null) return Enumerable.Empty<string>();
-		return SelectClause.Select(x => x.Alias);
-	}
+    public override IEnumerable<string> GetColumnNames()
+    {
+        if (SelectClause == null) return Enumerable.Empty<string>();
+        return SelectClause.Select(x => x.Alias);
+    }
 
-	public override IEnumerable<PhysicalTable> GetPhysicalTables()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
+    public override IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
 
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override IEnumerable<SelectQuery> GetInternalQueries()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
+    public override IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
 
-		yield return this;
+        yield return this;
 
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<SelectableItem> GetSelectableItems()
-	{
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause)
-			{
-				yield return item;
-			}
-		}
-	}
+    public IEnumerable<SelectableItem> GetSelectableItems()
+    {
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause)
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public IEnumerable<SelectableTable> GetSelectableTables()
-	{
-		if (FromClause == null) yield break;
-		foreach (var item in FromClause.GetSelectableTables()) yield return item;
-	}
+    public IEnumerable<SelectableTable> GetSelectableTables()
+    {
+        if (FromClause == null) yield break;
+        foreach (var item in FromClause.GetSelectableTables()) yield return item;
+    }
 
-	public override IEnumerable<CommonTable> GetCommonTables()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public override IEnumerable<CommonTable> GetCommonTables()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    public bool TryToValuesQuery([MaybeNullWhen(false)] out ValuesQuery query)
+    {
+        query = default;
+        if (SelectClause is null) return false;
+
+        var row = new ValueCollection(SelectClause.Select(x => x.Value).OfType<LiteralValue>().ToList<ValueBase>());
+        var q = new ValuesQuery();
+        q.Rows.Add(row);
+
+        foreach (var item in OperatableQueries)
+        {
+            if (item.Query is SelectQuery sq)
+            {
+                if (sq.TryToValuesQuery(out var vq))
+                {
+                    q.Rows.AddRange(vq.Rows);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (item.Query is ValuesQuery vq)
+            {
+                q.Rows.AddRange(vq.Rows);
+            }
+        }
+
+        // Conversion is not possible if the number of columns is different.
+        if (q.Rows.Min(x => x.Count()) != q.Rows.Max(x => x.Count()))
+        {
+            return false;
+        }
+
+        query = q;
+        return true;
+    }
 }

--- a/src/Carbunql/Values/ValueCollection.cs
+++ b/src/Carbunql/Values/ValueCollection.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Analysis.Parser;
+using Carbunql.Building;
 using Carbunql.Clauses;
 using Carbunql.Tables;
 using MessagePack;
@@ -9,216 +10,242 @@ namespace Carbunql.Values;
 [MessagePackObject(keyAsPropertyName: true)]
 public class ValueCollection : ValueBase, IList<ValueBase>, IQueryCommandable
 {
-	public ValueCollection()
-	{
-	}
+    public ValueCollection()
+    {
+    }
 
-	public ValueCollection(string text)
-	{
-		Collection.Add(new LiteralValue(text));
-	}
+    public ValueCollection(string text)
+    {
+        Collection.Add(new LiteralValue(text));
+    }
 
-	public ValueCollection(ValueBase item)
-	{
-		Collection.Add(item);
-	}
+    public ValueCollection(ValueBase item)
+    {
+        Collection.Add(item);
+    }
 
-	public ValueCollection(List<ValueBase> collection)
-	{
-		Collection.AddRange(collection);
-	}
+    public ValueCollection(List<ValueBase> collection)
+    {
+        Collection.AddRange(collection);
+    }
 
-	public ValueCollection(IEnumerable<string> values)
-	{
-		foreach (var item in values)
-		{
-			Collection.Add(new LiteralValue(item));
-		}
-	}
+    public ValueCollection(IEnumerable<string> values)
+    {
+        foreach (var item in values)
+        {
+            Collection.Add(new LiteralValue(item));
+        }
+    }
 
-	public ValueCollection(string tableAlias, IEnumerable<string> columns)
-	{
-		if (!columns.Any()) throw new ArgumentException(null, nameof(columns));
-		foreach (var column in columns)
-		{
-			Collection.Add(new ColumnValue(tableAlias, column));
-		}
-	}
+    public ValueCollection(string tableAlias, IEnumerable<string> columns)
+    {
+        if (!columns.Any()) throw new ArgumentException(null, nameof(columns));
+        foreach (var column in columns)
+        {
+            Collection.Add(new ColumnValue(tableAlias, column));
+        }
+    }
 
-	private List<ValueBase> Collection { get; init; } = new();
+    private List<ValueBase> Collection { get; init; } = new();
 
-	public IEnumerable<string> GetColumnNames()
-	{
-		foreach (var item in Collection) yield return item.GetDefaultName();
-	}
+    public IEnumerable<string> GetColumnNames()
+    {
+        foreach (var item in Collection) yield return item.GetDefaultName();
+    }
 
-	protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
-	{
-		foreach (var value in Collection)
-		{
-			foreach (var item in value.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
+    protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
+    {
+        foreach (var value in Collection)
+        {
+            foreach (var item in value.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
-	{
-		foreach (var value in Collection)
-		{
-			foreach (var item in value.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
+    {
+        foreach (var value in Collection)
+        {
+            foreach (var item in value.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	protected override IEnumerable<CommonTable> GetCommonTablesCore()
-	{
-		foreach (var value in Collection)
-		{
-			foreach (var item in value.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    protected override IEnumerable<CommonTable> GetCommonTablesCore()
+    {
+        foreach (var value in Collection)
+        {
+            foreach (var item in value.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
-	{
-		var isFirst = true;
-		foreach (var item in Collection)
-		{
-			if (isFirst)
-			{
-				isFirst = false;
-			}
-			else
-			{
-				yield return Token.Comma(this, parent);
-			}
-			foreach (var token in item.GetTokens(parent)) yield return token;
-		}
-	}
+    public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+    {
+        var isFirst = true;
+        foreach (var item in Collection)
+        {
+            if (isFirst)
+            {
+                isFirst = false;
+            }
+            else
+            {
+                yield return Token.Comma(this, parent);
+            }
+            foreach (var token in item.GetTokens(parent)) yield return token;
+        }
+    }
 
-	protected override IEnumerable<QueryParameter> GetParametersCore()
-	{
-		foreach (var item in Collection)
-		{
-			foreach (var p in item.GetParameters())
-			{
-				yield return p;
-			}
-		}
-	}
+    protected override IEnumerable<QueryParameter> GetParametersCore()
+    {
+        foreach (var item in Collection)
+        {
+            foreach (var p in item.GetParameters())
+            {
+                yield return p;
+            }
+        }
+    }
 
-	public void Add(string value)
-	{
-		Add(ValueParser.Parse(value));
-	}
+    public override IEnumerable<ValueBase> GetValues()
+    {
+        foreach (var item in this)
+        {
+            foreach (var value in item.GetValues())
+            {
+                yield return value;
+            }
+        }
+    }
 
-	public void Add(FromClause from, string column)
-	{
-		Add(from.Root.Alias, column);
-	}
 
-	public void Add(SelectableTable table, string column)
-	{
-		Add(table.Alias, column);
-	}
+    public void Add(string value)
+    {
+        Add(ValueParser.Parse(value));
+    }
 
-	public void Add(string table, string column)
-	{
-		var v = new ColumnValue(table, column);
-		Add(v);
-	}
+    public void Add(FromClause from, string column)
+    {
+        Add(from.Root.Alias, column);
+    }
 
-	public void Add(int value)
-	{
-		var v = new LiteralValue(value.ToString());
-		Add(v);
-	}
+    public void Add(SelectableTable table, string column)
+    {
+        Add(table.Alias, column);
+    }
 
-	public void Add(long value)
-	{
-		var v = new LiteralValue(value.ToString());
-		Add(v);
-	}
+    public void Add(string table, string column)
+    {
+        var v = new ColumnValue(table, column);
+        Add(v);
+    }
 
-	public void Add(decimal value)
-	{
-		var v = new LiteralValue(value.ToString());
-		Add(v);
-	}
+    public void Add(int value)
+    {
+        var v = new LiteralValue(value.ToString());
+        Add(v);
+    }
 
-	public void Add(double value)
-	{
-		var v = new LiteralValue(value.ToString());
-		Add(v);
-	}
+    public void Add(long value)
+    {
+        var v = new LiteralValue(value.ToString());
+        Add(v);
+    }
 
-	public void Add(DateTime value, string sufix = "::timestamp")
-	{
-		Add("'" + value.ToString() + "'" + sufix);
-	}
+    public void Add(decimal value)
+    {
+        var v = new LiteralValue(value.ToString());
+        Add(v);
+    }
 
-	#region implements IList<ValueBase>
-	public ValueBase this[int index]
-	{ get => ((IList<ValueBase>)Collection)[index]; set => ((IList<ValueBase>)Collection)[index] = value; }
+    public void Add(double value)
+    {
+        var v = new LiteralValue(value.ToString());
+        Add(v);
+    }
 
-	public int Count => ((ICollection<ValueBase>)Collection).Count;
+    public void Add(DateTime value, string sufix = "::timestamp")
+    {
+        Add("'" + value.ToString() + "'" + sufix);
+    }
 
-	public bool IsReadOnly => ((ICollection<ValueBase>)Collection).IsReadOnly;
+    public SelectQuery ToPlainSelectQuery(IList<string> columnAlias)
+    {
+        var sq = new SelectQuery();
+        sq.SelectClause ??= new();
 
-	public void Add(ValueBase item)
-	{
-		((ICollection<ValueBase>)Collection).Add(item);
-	}
+        var index = 0;
+        foreach (var column in this)
+        {
+            sq.SelectClause!.Add(column.ToSelectable(columnAlias[index]));
+            index++;
+        }
+        return sq;
+    }
 
-	public void Clear()
-	{
-		((ICollection<ValueBase>)Collection).Clear();
-	}
+    #region implements IList<ValueBase>
+    public ValueBase this[int index]
+    { get => ((IList<ValueBase>)Collection)[index]; set => ((IList<ValueBase>)Collection)[index] = value; }
 
-	public bool Contains(ValueBase item)
-	{
-		return ((ICollection<ValueBase>)Collection).Contains(item);
-	}
+    public int Count => ((ICollection<ValueBase>)Collection).Count;
 
-	public void CopyTo(ValueBase[] array, int arrayIndex)
-	{
-		((ICollection<ValueBase>)Collection).CopyTo(array, arrayIndex);
-	}
+    public bool IsReadOnly => ((ICollection<ValueBase>)Collection).IsReadOnly;
 
-	public IEnumerator<ValueBase> GetEnumerator()
-	{
-		return ((IEnumerable<ValueBase>)Collection).GetEnumerator();
-	}
+    public void Add(ValueBase item)
+    {
+        ((ICollection<ValueBase>)Collection).Add(item);
+    }
 
-	public int IndexOf(ValueBase item)
-	{
-		return ((IList<ValueBase>)Collection).IndexOf(item);
-	}
+    public void Clear()
+    {
+        ((ICollection<ValueBase>)Collection).Clear();
+    }
 
-	public void Insert(int index, ValueBase item)
-	{
-		((IList<ValueBase>)Collection).Insert(index, item);
-	}
+    public bool Contains(ValueBase item)
+    {
+        return ((ICollection<ValueBase>)Collection).Contains(item);
+    }
 
-	public bool Remove(ValueBase item)
-	{
-		return ((ICollection<ValueBase>)Collection).Remove(item);
-	}
+    public void CopyTo(ValueBase[] array, int arrayIndex)
+    {
+        ((ICollection<ValueBase>)Collection).CopyTo(array, arrayIndex);
+    }
 
-	public void RemoveAt(int index)
-	{
-		((IList<ValueBase>)Collection).RemoveAt(index);
-	}
+    public IEnumerator<ValueBase> GetEnumerator()
+    {
+        return ((IEnumerable<ValueBase>)Collection).GetEnumerator();
+    }
 
-	IEnumerator IEnumerable.GetEnumerator()
-	{
-		return ((IEnumerable)Collection).GetEnumerator();
-	}
-	#endregion
+    public int IndexOf(ValueBase item)
+    {
+        return ((IList<ValueBase>)Collection).IndexOf(item);
+    }
+
+    public void Insert(int index, ValueBase item)
+    {
+        ((IList<ValueBase>)Collection).Insert(index, item);
+    }
+
+    public bool Remove(ValueBase item)
+    {
+        return ((ICollection<ValueBase>)Collection).Remove(item);
+    }
+
+    public void RemoveAt(int index)
+    {
+        ((IList<ValueBase>)Collection).RemoveAt(index);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return ((IEnumerable)Collection).GetEnumerator();
+    }
+    #endregion
 }

--- a/src/Carbunql/ValuesQuery.cs
+++ b/src/Carbunql/ValuesQuery.cs
@@ -12,266 +12,293 @@ namespace Carbunql;
 [MessagePackObject(keyAsPropertyName: true)]
 public class ValuesQuery : ReadQuery
 {
-	public ValuesQuery()
-	{
-	}
+    public ValuesQuery()
+    {
+    }
 
-	public ValuesQuery(List<ValueCollection> rows)
-	{
-		Rows = rows;
-	}
+    public ValuesQuery(List<ValueCollection> rows)
+    {
+        Rows = rows;
+    }
 
-	public ValuesQuery(string query)
-	{
-		var q = ValuesQueryParser.Parse(query);
-		Rows = q.Rows;
-		OperatableQueries = q.OperatableQueries;
-		OrderClause = q.OrderClause;
-		LimitClause = q.LimitClause;
-	}
+    public ValuesQuery(string query)
+    {
+        var q = ValuesQueryParser.Parse(query);
+        Rows = q.Rows;
+        OperatableQueries = q.OperatableQueries;
+        OrderClause = q.OrderClause;
+        LimitClause = q.LimitClause;
+    }
 
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(IEnumerable<object> matrix)
-	{
-		foreach (var row in matrix)
-		{
-			var lst = new List<ValueBase>();
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(IEnumerable<object> matrix)
+    {
+        foreach (var row in matrix)
+        {
+            var lst = new List<ValueBase>();
 
-			foreach (var column in row.GetType().GetProperties().Where(x => x.CanRead && x.CanWrite).Select(x => x.GetValue(row)))
-			{
-				if (column == null || column.ToString() == null)
-				{
-					lst.Add(new LiteralValue("null"));
-				}
-				else
-				{
-					var v = $"\"{column}\"";
-					lst.Add(ValueParser.Parse(column.ToString()!));
-				}
-			}
-			Rows.Add(new ValueCollection(lst));
-		}
-	}
+            foreach (var column in row.GetType().GetProperties().Where(x => x.CanRead && x.CanWrite).Select(x => x.GetValue(row)))
+            {
+                if (column == null || column.ToString() == null)
+                {
+                    lst.Add(new LiteralValue("null"));
+                }
+                else
+                {
+                    var v = $"\"{column}\"";
+                    lst.Add(ValueParser.Parse(column.ToString()!));
+                }
+            }
+            Rows.Add(new ValueCollection(lst));
+        }
+    }
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(IEnumerable<object> matrix, string placeholderIndentifer)
-	{
-		var r = 0;
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(IEnumerable<object> matrix, string placeholderIndentifer)
+    {
+        var r = 0;
 
-		foreach (var row in matrix)
-		{
-			var lst = new List<ValueBase>();
-			var c = 0;
-			foreach (var column in row.GetType().GetProperties().Where(x => x.CanRead && x.CanWrite).Select(x => x.GetValue(row)))
-			{
-				var name = $"r{r}c{c}";
-				var v = placeholderIndentifer + name;
-				lst.Add(ValueParser.Parse(v));
-				AddParameter(name, column);
-				c++;
-			}
-			Rows.Add(new ValueCollection(lst));
-			r++;
-		}
-	}
+        foreach (var row in matrix)
+        {
+            var lst = new List<ValueBase>();
+            var c = 0;
+            foreach (var column in row.GetType().GetProperties().Where(x => x.CanRead && x.CanWrite).Select(x => x.GetValue(row)))
+            {
+                var name = $"r{r}c{c}";
+                var v = placeholderIndentifer + name;
+                lst.Add(ValueParser.Parse(v));
+                AddParameter(name, column);
+                c++;
+            }
+            Rows.Add(new ValueCollection(lst));
+            r++;
+        }
+    }
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(string[,] matrix)
-	{
-		for (int row = 0; row < matrix.GetLength(0); row++)
-		{
-			var lst = new List<ValueBase>();
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(string[,] matrix)
+    {
+        for (int row = 0; row < matrix.GetLength(0); row++)
+        {
+            var lst = new List<ValueBase>();
 
-			for (int column = 0; column < matrix.GetLength(1); column++)
-			{
-				var v = $"\"{matrix[row, column]}\"";
-				lst.Add(ValueParser.Parse(v));
-			}
-			Rows.Add(new ValueCollection(lst));
-		}
-	}
+            for (int column = 0; column < matrix.GetLength(1); column++)
+            {
+                var v = $"\"{matrix[row, column]}\"";
+                lst.Add(ValueParser.Parse(v));
+            }
+            Rows.Add(new ValueCollection(lst));
+        }
+    }
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(IEnumerable<IEnumerable<string>> matrix)
-	{
-		foreach (var row in matrix)
-		{
-			var lst = new List<ValueBase>();
-			foreach (var column in row)
-			{
-				var v = $"\"{column}\"";
-				lst.Add(ValueParser.Parse(v));
-			}
-			Rows.Add(new ValueCollection(lst));
-		}
-	}
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(IEnumerable<IEnumerable<string>> matrix)
+    {
+        foreach (var row in matrix)
+        {
+            var lst = new List<ValueBase>();
+            foreach (var column in row)
+            {
+                var v = $"\"{column}\"";
+                lst.Add(ValueParser.Parse(v));
+            }
+            Rows.Add(new ValueCollection(lst));
+        }
+    }
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(string[,] matrix, string placeholderIndentifer)
-	{
-		for (int row = 0; row < matrix.GetLength(0); row++)
-		{
-			var lst = new List<ValueBase>();
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(string[,] matrix, string placeholderIndentifer)
+    {
+        for (int row = 0; row < matrix.GetLength(0); row++)
+        {
+            var lst = new List<ValueBase>();
 
-			for (int column = 0; column < matrix.GetLength(1); column++)
-			{
-				var name = $"r{row}c{column}";
-				var v = placeholderIndentifer + name;
-				lst.Add(ValueParser.Parse(v));
-				AddParameter(name, matrix[row, column]);
-			}
-			Rows.Add(new ValueCollection(lst));
-		}
-	}
+            for (int column = 0; column < matrix.GetLength(1); column++)
+            {
+                var name = $"r{row}c{column}";
+                var v = placeholderIndentifer + name;
+                lst.Add(ValueParser.Parse(v));
+                AddParameter(name, matrix[row, column]);
+            }
+            Rows.Add(new ValueCollection(lst));
+        }
+    }
 
-	[Obsolete("This feature has been deprecated. Consider building it outside of class.")]
-	public ValuesQuery(IEnumerable<IEnumerable<string>> matrix, string placeholderIndentifer)
-	{
-		var r = 0;
-		foreach (var row in matrix)
-		{
-			var c = 0;
-			var lst = new List<ValueBase>();
-			foreach (var column in row)
-			{
-				var name = $"r{r}c{c}";
-				var v = placeholderIndentifer + name;
-				lst.Add(ValueParser.Parse(v));
-				AddParameter(name, column);
-				c++;
-			}
-			Rows.Add(new ValueCollection(lst));
-			r++;
-		}
-	}
+    [Obsolete("This feature has been deprecated. Consider building it outside of class.")]
+    public ValuesQuery(IEnumerable<IEnumerable<string>> matrix, string placeholderIndentifer)
+    {
+        var r = 0;
+        foreach (var row in matrix)
+        {
+            var c = 0;
+            var lst = new List<ValueBase>();
+            foreach (var column in row)
+            {
+                var name = $"r{r}c{c}";
+                var v = placeholderIndentifer + name;
+                lst.Add(ValueParser.Parse(v));
+                AddParameter(name, column);
+                c++;
+            }
+            Rows.Add(new ValueCollection(lst));
+            r++;
+        }
+    }
 
-	public List<ValueCollection> Rows { get; init; } = new();
+    public List<ValueCollection> Rows { get; init; } = new();
 
-	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
-	{
-		var clause = Token.Reserved(this, parent, "values");
-		yield return clause;
+    public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+    {
+        var clause = Token.Reserved(this, parent, "values");
+        yield return clause;
 
-		var isFirst = true;
-		foreach (var item in Rows)
-		{
-			if (isFirst)
-			{
-				isFirst = false;
-			}
-			else
-			{
-				yield return Token.Comma(this, clause);
-			}
-			var bracket = Token.ReservedBracketStart(this, clause);
-			yield return bracket;
-			foreach (var token in item.GetTokens(bracket)) yield return token;
-			yield return Token.ReservedBracketEnd(this, clause);
-		}
-	}
+        var isFirst = true;
+        foreach (var item in Rows)
+        {
+            if (isFirst)
+            {
+                isFirst = false;
+            }
+            else
+            {
+                yield return Token.Comma(this, clause);
+            }
+            var bracket = Token.ReservedBracketStart(this, clause);
+            yield return bracket;
+            foreach (var token in item.GetTokens(bracket)) yield return token;
+            yield return Token.ReservedBracketEnd(this, clause);
+        }
+    }
 
-	public override WithClause? GetWithClause() => null;
+    public override WithClause? GetWithClause() => null;
 
-	public override SelectClause? GetSelectClause() => null;
+    public override SelectClause? GetSelectClause() => null;
 
-	public override IEnumerable<SelectQuery> GetInternalQueries()
-	{
-		foreach (var row in Rows)
-		{
-			foreach (var item in row.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
+    public override IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        foreach (var row in Rows)
+        {
+            foreach (var item in row.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override IEnumerable<PhysicalTable> GetPhysicalTables()
-	{
-		foreach (var row in Rows)
-		{
-			foreach (var item in row.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public override IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        foreach (var row in Rows)
+        {
+            foreach (var item in row.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override IEnumerable<CommonTable> GetCommonTables()
-	{
-		foreach (var row in Rows)
-		{
-			foreach (var item in row.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
+    public override IEnumerable<CommonTable> GetCommonTables()
+    {
+        foreach (var row in Rows)
+        {
+            foreach (var item in row.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
 
-	public override SelectQuery GetOrNewSelectQuery()
-	{
-		return ToSelectQuery();
-	}
+    public override SelectQuery GetOrNewSelectQuery()
+    {
+        return ToSelectQuery();
+    }
 
-	public override IEnumerable<QueryParameter> GetInnerParameters()
-	{
-		foreach (var item in Rows)
-		{
-			foreach (var p in item.GetParameters())
-			{
-				yield return p;
-			}
-		}
-	}
+    public override IEnumerable<QueryParameter> GetInnerParameters()
+    {
+        foreach (var item in Rows)
+        {
+            foreach (var p in item.GetParameters())
+            {
+                yield return p;
+            }
+        }
+    }
 
-	public SelectQuery ToSelectQuery()
-	{
-		var lst = GetDefaultColumnAliases();
-		return ToSelectQuery(lst);
-	}
+    public SelectQuery ToPlainSelectQuery()
+    {
+        var lst = GetDefaultColumnAliases();
+        return ToPlainSelectQuery(lst);
+    }
 
-	public SelectQuery ToSelectQuery(IEnumerable<string> columnAlias)
-	{
-		var sq = new SelectQuery();
-		var f = sq.From(ToSelectableTable(columnAlias));
+    public SelectQuery ToPlainSelectQuery(IEnumerable<string> columnAlias)
+    {
+        var columns = columnAlias.ToList();
+        SelectQuery? sq = null;
 
-		foreach (var item in columnAlias) sq.Select(f, item);
+        foreach (var row in Rows)
+        {
+            if (sq == null)
+            {
+                sq = row.ToPlainSelectQuery(columns);
+            }
+            else
+            {
+                sq.AddOperatableValue("union all", row.ToPlainSelectQuery(columns));
+            }
+        }
+        if (sq == null) throw new InvalidOperationException();
 
-		sq.OrderClause = OrderClause;
-		sq.LimitClause = LimitClause;
+        return sq;
+    }
 
-		sq.Parameters = Parameters;
+    public SelectQuery ToSelectQuery()
+    {
+        var lst = GetDefaultColumnAliases();
+        return ToSelectQuery(lst);
+    }
 
-		return sq;
-	}
+    public SelectQuery ToSelectQuery(IEnumerable<string> columnAlias)
+    {
+        var sq = new SelectQuery();
+        var f = sq.From(ToSelectableTable(columnAlias));
 
-	private List<string> GetDefaultColumnAliases()
-	{
-		if (!Rows.Any() || Rows.First().Count == 0) throw new Exception();
-		var cnt = Rows.First().Count;
+        foreach (var item in columnAlias) sq.Select(f, item);
 
-		var lst = new List<string>();
-		cnt.ForEach(x => lst.Add("c" + x));
+        sq.OrderClause = OrderClause;
+        sq.LimitClause = LimitClause;
 
-		return lst;
-	}
+        sq.Parameters = Parameters;
 
-	public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
-	{
-		var vt = new VirtualTable(this);
-		if (columnAliases == null)
-		{
-			var lst = GetDefaultColumnAliases();
-			return vt.ToSelectable("v", lst);
-		}
-		else
-		{
-			return vt.ToSelectable("v", columnAliases);
-		}
-	}
+        return sq;
+    }
 
-	public override IEnumerable<string> GetColumnNames()
-	{
-		return Enumerable.Empty<string>();
-	}
+    private List<string> GetDefaultColumnAliases()
+    {
+        if (!Rows.Any() || Rows.First().Count == 0) throw new Exception();
+        var cnt = Rows.First().Count;
+
+        var lst = new List<string>();
+        cnt.ForEach(x => lst.Add("c" + x));
+
+        return lst;
+    }
+
+    public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
+    {
+        var vt = new VirtualTable(this);
+        if (columnAliases == null)
+        {
+            var lst = GetDefaultColumnAliases();
+            return vt.ToSelectable("v", lst);
+        }
+        else
+        {
+            return vt.ToSelectable("v", columnAliases);
+        }
+    }
+
+    public override IEnumerable<string> GetColumnNames()
+    {
+        return Enumerable.Empty<string>();
+    }
 }

--- a/test/Carbunql.Building.Test/InsertQueryTest.cs
+++ b/test/Carbunql.Building.Test/InsertQueryTest.cs
@@ -1,0 +1,161 @@
+﻿using Carbunql.Analysis;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Carbunql.Building.Test;
+
+public class InsertQueryTest
+{
+    private readonly QueryCommandMonitor Monitor;
+
+    public InsertQueryTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
+
+    [Fact]
+    public void InsertValuesToInsertSelect()
+    {
+        var text = @"
+INSERT INTO sale (sale_date,price,created_at) VALUES
+     ('2023-01-01',160,'2024-01-11 14:29:01.618'),
+     ('2023-03-12',200,'2024-01-11 14:29:01.618')";
+
+        var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+SELECT
+    '2023-01-01' AS sale_date,
+    160 AS price,
+    '2024-01-11 14:29:01.618' AS created_at
+UNION ALL
+SELECT
+    '2023-03-12' AS sale_date,
+    200 AS price,
+    '2024-01-11 14:29:01.618' AS created_at";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertSelect(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(34, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void InsertSelectToInsertValues()
+    {
+        var text = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+SELECT
+    '2023-01-01' AS sale_date,
+    160 AS price,
+    '2024-01-11 14:29:01.618' AS created_at
+UNION ALL
+SELECT
+    '2023-03-12' AS sale_date,
+    200 AS price,
+    '2024-01-11 14:29:01.618' AS created_at";
+
+        var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+VALUES
+    ('2023-01-01', 160, '2024-01-11 14:29:01.618'),
+    ('2023-03-12', 200, '2024-01-11 14:29:01.618')";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertValues(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(25, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void InsertSelectToInsertValues_calc()
+    {
+        var text = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+SELECT
+    '2023-01-01' AS sale_date,
+    160 + 10 AS price,
+    '2024-01-11 14:29:01.618' AS created_at
+UNION ALL
+SELECT
+    '2023-03-12' AS sale_date,
+    200 * 20 AS price,
+    '2024-01-11 14:29:01.618' AS created_at";
+
+        var expect = @"INSERT INTO
+    SALE(sale_date, price, created_at)
+VALUES
+    ('2023-01-01', 160 + 10, '2024-01-11 14:29:01.618'),
+    ('2023-03-12', 200 * 20, '2024-01-11 14:29:01.618')";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertValues(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(29, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void CatalogShemaTable()
+    {
+        var text = @"
+INSERT INTO catalog.schema.sale (sale_date,price,created_at) VALUES
+     ('2023-01-01',160,'2024-01-11 14:29:01.618'),
+     ('2023-03-12',200,'2024-01-11 14:29:01.618')";
+
+        var expect = @"INSERT INTO
+    catalog.schema.sale (
+        sale_date, price, created_at
+    )
+VALUES
+    ('2023-01-01', 160, '2024-01-11 14:29:01.618'),
+    ('2023-03-12', 200, '2024-01-11 14:29:01.618')";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertSelect(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(27, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
+}

--- a/test/Carbunql.Building.Test/MergeTest.cs
+++ b/test/Carbunql.Building.Test/MergeTest.cs
@@ -2,52 +2,73 @@ using Carbunql.Analysis;
 using Carbunql.Values;
 using Xunit.Abstractions;
 
-
 namespace Carbunql.Building.Test;
 
 public class MergeTest
 {
-	private readonly QueryCommandMonitor Monitor;
+    private readonly QueryCommandMonitor Monitor;
 
-	public MergeTest(ITestOutputHelper output)
-	{
-		Monitor = new QueryCommandMonitor(output);
-	}
+    public MergeTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
 
-	[Fact]
-	public void MergeQuery()
-	{
-		var sql = "select a.id, a.sub_id, a.v1, a.v2 from table as a";
-		var q = QueryParser.Parse(sql);
+    [Fact]
+    public void MergeQuery()
+    {
+        var sql = "select a.id, a.sub_id, a.v1, a.v2 from table as a";
+        var q = QueryParser.Parse(sql);
 
-		var uq = q.ToMergeQuery("destination_table", new[] { "id", "sub_id" });
-		uq.AddMatchedUpdate();
-		uq.AddNotMathcedInsertAsAutoNumber();
-		uq.AddNotMatchedInsert();
+        var uq = q.ToMergeQuery("destination_table", new[] { "id", "sub_id" });
+        uq.AddMatchedUpdate();
+        uq.AddNotMathcedInsertAsAutoNumber();
+        uq.AddNotMatchedInsert();
 
-		Monitor.Log(uq);
+        Monitor.Log(uq);
 
-		var lst = uq.GetTokens().ToList();
+        var lst = uq.GetTokens().ToList();
 
-		Assert.Equal(119, lst.Count());
-	}
+        Assert.Equal(119, lst.Count());
+    }
 
-	[Fact]
-	public void MergeDeleteQuery()
-	{
-		var sql = "select a.tid, a.balance, a.deleted from (values (123, 10, true)) as a(tid, balance, deleted)";
-		var q = QueryParser.Parse(sql);
+    [Fact]
+    public void MergeDeleteQuery()
+    {
+        var sql = "select a.tid, a.balance, a.deleted from (values (123, 10, true)) as a(tid, balance, deleted)";
+        var q = QueryParser.Parse(sql);
 
-		var uq = q.ToMergeQuery("target", new[] { "tid" });
-		uq.AddMatchedDelete(() =>
-		{
-			return new ColumnValue(uq.DatasourceAlias, "deleted").True();
-		});
+        var uq = q.ToMergeQuery("target", new[] { "tid" });
+        uq.AddMatchedDelete(() =>
+        {
+            return new ColumnValue(uq.DatasourceAlias, "deleted").True();
+        });
 
-		Monitor.Log(uq);
+        Monitor.Log(uq);
 
-		var lst = uq.GetTokens().ToList();
+        var lst = uq.GetTokens().ToList();
 
-		Assert.Equal(58, lst.Count());
-	}
+        Assert.Equal(58, lst.Count());
+
+        var expect = @"MERGE INTO
+    target AS d
+USING
+    (
+        SELECT
+            a.tid,
+            a.balance,
+            a.deleted
+        FROM
+            (
+                VALUES
+                    (123, 10, true)
+            ) AS a (
+                tid, balance, deleted
+            )
+    ) AS s ON d.tid = s.tid
+WHEN MATCHED
+    AND s.deleted = true
+THEN DELETE";
+
+        Assert.Equal(expect, uq.ToText(), true, true, true);
+    }
 }


### PR DESCRIPTION
Fixed a bug where insert queries that specified a schema name could not be parsed. 
Added a function to convert Select query to Values query (TryToValuesQuery).
Added a query to convert a Values query to a Select query without a table (ToPlainSelectQuery). 
Added a function to convert InsertSelect format to InsertValues format (TryConvertToInsertSelect). 
Added a function to convert InsertValues format to InsertSelect format (TryConvertToInsertValues).