### PR TITLE
Corrected garbled characters

### DIFF
--- a/demo/CarbunqlWeb/Pages/Format.razor
+++ b/demo/CarbunqlWeb/Pages/Format.razor
@@ -17,7 +17,7 @@
         <div class="col-md-12 p-3">
             <RadzenText TextStyle="TextStyle.H4">Format</RadzenText>
 
-            <RadzenText>SQL can be formatted.iselect, values, insert, create table, create index, alter tablej</RadzenText>
+            <RadzenText>SQL can be formatted.(select, values, insert, create table, create index, alter table)</RadzenText>
             
              <RadzenCard>
                 <RadzenText TextStyle="TextStyle.Subtitle2">Source code</RadzenText>


### PR DESCRIPTION
Corrected because double-byte characters were used in the symbol.