### PR TITLE
Now supports parsing of IN clauses with multiple columns as arguments.

### DIFF
--- a/src/Carbunql/Analysis/Parser/BracketValueParser.cs
+++ b/src/Carbunql/Analysis/Parser/BracketValueParser.cs
@@ -24,7 +24,7 @@ public static class BracketValueParser
 		}
 		else
 		{
-			var v = ValueParser.Parse(ir);
+			var v = ValueCollectionParser.Parse(ir);
 			return new BracketValue(v);
 		}
 	}

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -7,7 +7,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.7.5</Version>
+		<Version>0.7.6</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/test/Carbunql.Analysis.Test/WhereClauseParserTest.cs
+++ b/test/Carbunql.Analysis.Test/WhereClauseParserTest.cs
@@ -5,76 +5,120 @@ namespace Carbunql.Analysis.Test;
 
 public class WhereClauseParserTest
 {
-	private readonly QueryCommandMonitor Monitor;
+    private readonly QueryCommandMonitor Monitor;
 
-	public WhereClauseParserTest(ITestOutputHelper output)
-	{
-		Monitor = new QueryCommandMonitor(output);
-	}
+    public WhereClauseParserTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
 
-	[Fact]
-	public void Default()
-	{
-		var text = @"tbl.col1 = 1 
+    [Fact]
+    public void Default()
+    {
+        var text = @"tbl.col1 = 1 
 and (tbl.col2 = 2 or tbl.col3 = 3) 
 and (tbl.col2 = 2 and tbl.col3 = 3) 
 and t1.c1 between 1 and 10";
-		var item = WhereClauseParser.Parse(text);
-		Monitor.Log(item);
-	}
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
+    }
 
-	[Fact]
-	public void ParseNull()
-	{
-		var text = @"tbl.col1 is null and tbl.col2 is not null";
-		var item = WhereClauseParser.Parse(text);
-		Monitor.Log(item);
+    [Fact]
+    public void ParseNull()
+    {
+        var text = @"tbl.col1 is null and tbl.col2 is not null";
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
 
-		var lst = item.GetTokens(null).ToList();
-		Assert.Equal(12, lst.Count());
+        var lst = item.GetTokens(null).ToList();
+        Assert.Equal(12, lst.Count());
 
-		Assert.Equal("col1", lst[3].Text);
-		Assert.Equal("is", lst[4].Text);
-		Assert.Equal("null", lst[5].Text);
+        Assert.Equal("col1", lst[3].Text);
+        Assert.Equal("is", lst[4].Text);
+        Assert.Equal("null", lst[5].Text);
 
-		Assert.Equal("col2", lst[9].Text);
-		Assert.Equal("is not", lst[10].Text);
-		Assert.Equal("null", lst[11].Text);
-	}
+        Assert.Equal("col2", lst[9].Text);
+        Assert.Equal("is not", lst[10].Text);
+        Assert.Equal("null", lst[11].Text);
+    }
 
-	[Fact]
-	public void ParseIn()
-	{
-		var text = @"tbl.col1 in (1, 2, 3)";
-		var item = WhereClauseParser.Parse(text);
-		Monitor.Log(item);
+    [Fact]
+    public void ParseIn()
+    {
+        var text = @"tbl.col1 in (1, 2, 3)";
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
 
-		var lst = item.GetTokens(null).ToList();
-		Assert.Equal(12, lst.Count());
+        var lst = item.GetTokens(null).ToList();
+        Assert.Equal(12, lst.Count());
 
-		Assert.Equal("col1", lst[3].Text);
-		Assert.Equal("in", lst[4].Text);
-		Assert.Equal("(", lst[5].Text);
-		Assert.Equal("1", lst[6].Text);
-		Assert.Equal(",", lst[7].Text);
+        Assert.Equal("col1", lst[3].Text);
+        Assert.Equal("in", lst[4].Text);
+        Assert.Equal("(", lst[5].Text);
+        Assert.Equal("1", lst[6].Text);
+        Assert.Equal(",", lst[7].Text);
 
-		Assert.Equal(")", lst[11].Text);
-	}
+        Assert.Equal(")", lst[11].Text);
+    }
 
-	[Fact]
-	public void ParseInSubQuery()
-	{
-		var text = @"tbl.col1 in (select id from table_b)";
-		var item = WhereClauseParser.Parse(text);
-		Monitor.Log(item);
+    [Fact]
+    public void ParseInSubQuery()
+    {
+        var text = @"tbl.col1 in (select id from table_b)";
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
 
-		var lst = item.GetTokens(null).ToList();
-		Assert.Equal(11, lst.Count());
+        var lst = item.GetTokens(null).ToList();
+        Assert.Equal(11, lst.Count());
 
-		Assert.Equal("in", lst[4].Text);
-		Assert.Equal("(", lst[5].Text);
-		Assert.Equal("select", lst[6].Text);
+        Assert.Equal("in", lst[4].Text);
+        Assert.Equal("(", lst[5].Text);
+        Assert.Equal("select", lst[6].Text);
 
-		Assert.Equal(")", lst[10].Text);
-	}
+        Assert.Equal(")", lst[10].Text);
+    }
+
+    [Fact]
+    public void ParseInSubQuery_MultipleColumns()
+    {
+        var text = @"(d.id, d.sub_id) in (select x.id, x.sub_id from data_2 as x)";
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
+
+        var lst = item.GetTokens(null).ToList();
+        Assert.Equal(25, lst.Count());
+
+        var expect = @"WHERE
+    (d.id, d.sub_id) IN (
+        SELECT
+            x.id,
+            x.sub_id
+        FROM
+            data_2 AS x
+    )";
+
+        Assert.Equal(expect, item.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void ParseInSubQuery_MultipleColumns_Calc()
+    {
+        var text = @"(1 + 2 * 3, 4 - 5 / 6) in (select x.id, x.sub_id from data_2 as x)";
+        var item = WhereClauseParser.Parse(text);
+        Monitor.Log(item);
+
+        var lst = item.GetTokens(null).ToList();
+        Assert.Equal(25, lst.Count());
+
+        var expect = @"WHERE
+    (d.id, d.sub_id) IN (
+        SELECT
+            x.id,
+            x.sub_id
+        FROM
+            data_2 AS x
+    )";
+
+        Assert.Equal(expect, item.ToText(), true, true, true);
+    }
 }

--- a/test/Carbunql.Analysis.Test/WhereClauseParserTest.cs
+++ b/test/Carbunql.Analysis.Test/WhereClauseParserTest.cs
@@ -108,10 +108,10 @@ and t1.c1 between 1 and 10";
         Monitor.Log(item);
 
         var lst = item.GetTokens(null).ToList();
-        Assert.Equal(25, lst.Count());
+        Assert.Equal(29, lst.Count());
 
         var expect = @"WHERE
-    (d.id, d.sub_id) IN (
+    (1 + 2 * 3, 4 - 5 / 6) IN (
         SELECT
             x.id,
             x.sub_id

--- a/test/Carbunql.Building.Test/InsertQueryTest.cs
+++ b/test/Carbunql.Building.Test/InsertQueryTest.cs
@@ -1,9 +1,4 @@
 ﻿using Carbunql.Analysis;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Carbunql.Building.Test;


### PR DESCRIPTION
Fixed to use ValueCollectionParser to parse when parentheses appear.