### PR TITLE
Fixed a bug where TryToValuesQuery did not work correctly.

### DIFF
--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -382,7 +382,7 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
         query = default;
         if (SelectClause is null) return false;
 
-        var row = new ValueCollection(SelectClause.Select(x => x.Value).OfType<LiteralValue>().ToList<ValueBase>());
+        var row = new ValueCollection(SelectClause.Select(x => x.Value).ToList<ValueBase>());
         var q = new ValuesQuery();
         q.Rows.Add(row);
 

--- a/test/Carbunql.Building.Test/InsertQueryTest.cs
+++ b/test/Carbunql.Building.Test/InsertQueryTest.cs
@@ -193,4 +193,68 @@ SELECT
         Assert.Equal(36, lst.Count);
         Assert.Equal(expect, iq.ToText(), true, true, true);
     }
+
+    [Fact]
+    public void InsertSelectToInsertValues_DiverseValues()
+    {
+        var text = @"INSERT INTO
+    sale(col1, col2, col3, col4)
+SELECT
+    now() AS col1,
+    :price AS col2,
+    current_timestamp AS col3,
+    null::int as col4";
+
+        var expect = @"INSERT INTO
+    sale(col1, col2, col3, col4)
+VALUES
+    (NOW(), :price, current_timestamp, null::int)";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertValues(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(25, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void InsertValuesToInsertSelect_DiverseValues()
+    {
+        var text = @"INSERT INTO
+    sale(col1, col2, col3, col4)
+VALUES
+    (NOW(), :price, current_timestamp, null::int)";
+
+        var expect = @"INSERT INTO
+    sale(col1, col2, col3, col4)
+SELECT
+    NOW() AS col1,
+    :price AS col2,
+    current_timestamp AS col3,
+    null::int as col4";
+
+        var iq = InsertQueryParser.Parse(text);
+        if (iq == null) throw new Exception();
+
+        if (iq.TryConvertToInsertSelect(out var x))
+        {
+            iq = x;
+        }
+
+        Monitor.Log(iq);
+
+        var lst = iq.GetTokens().ToList();
+
+        Assert.Equal(31, lst.Count);
+        Assert.Equal(expect, iq.ToText(), true, true, true);
+    }
 }


### PR DESCRIPTION
Fixed a bug where information other than LiteralValue was omitted when converting a Select query to a Values query.