### PR TITLE
Experimental: Allowed selection queries to have types. 

### DIFF
--- a/src/Carbunql.Postgres/FromnExtension.cs
+++ b/src/Carbunql.Postgres/FromnExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Carbunql.Building;
 using Carbunql.Clauses;
+using Carbunql.Postgres.Linq;
 
 namespace Carbunql.Postgres;
 
@@ -23,5 +24,12 @@ public static class FromnExtension
         source.As(alias);
         var r = (T)Activator.CreateInstance(typeof(T))!;
         return (source, r);
+    }
+
+    public static (FromClause, T) FromAs<T>(this SelectQuery source, SelectQuery<T> query, string alias)
+    {
+        var r = (T)Activator.CreateInstance(typeof(T))!;
+        var (from, _) = source.From(query).As(alias);
+        return (from, r);
     }
 }

--- a/src/Carbunql.Postgres/SelectQuery.cs
+++ b/src/Carbunql.Postgres/SelectQuery.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Carbunql.Postgres;
+
+public class SelectQuery<T> : SelectQuery
+{
+
+}

--- a/src/Carbunql.Postgres/SelectQuery.cs
+++ b/src/Carbunql.Postgres/SelectQuery.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Carbunql.Postgres;
+﻿namespace Carbunql.Postgres;
 
 public class SelectQuery<T> : SelectQuery
 {
+    public SelectQuery() : base()
+    {
+    }
 
+    public SelectQuery(string query) : base(query)
+    {
+    }
 }

--- a/test/Carbunql.Postgres.Test/Carbunql.Postgres.Test.csproj
+++ b/test/Carbunql.Postgres.Test/Carbunql.Postgres.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Carbunql.Postgres.Test/SampleQuery.cs
+++ b/test/Carbunql.Postgres.Test/SampleQuery.cs
@@ -1,0 +1,31 @@
+﻿namespace Carbunql.Postgres.Test;
+
+public static class SampleQuery
+{
+    public static string CommandText =>
+"""
+SELECT
+    a.a_id,
+    a.text,
+    b.value
+FROM
+    table_a AS a
+    INNER JOIN table_b AS b ON a.a_id = b.a_id
+""";
+
+    public static SelectQuery<Row> Query => GetQuery();
+
+    private static SelectQuery<Row>? QueryCache;
+
+    private static SelectQuery<Row> GetQuery()
+    {
+        if (QueryCache == null) QueryCache = new SelectQuery<Row>(CommandText);
+        return QueryCache;
+    }
+
+    public readonly record struct Row(
+        int a_id,
+        string text,
+        int value
+    );
+}

--- a/test/Carbunql.Postgres.Test/SubQueryText.cs
+++ b/test/Carbunql.Postgres.Test/SubQueryText.cs
@@ -153,13 +153,42 @@ FROM
         return sq;
     }
 
+
+    [Fact]
+    public void QueryClassTest()
+    {
+        var sq = new SelectQuery();
+        var (from, a) = sq.FromAs(SampleQuery.Query, "a");
+
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.value * 2).As("value");
+
+        Monitor.Log(sq);
+
+        Assert.Equal(45, sq.GetTokens().ToList().Count);
+
+        var sql = @"SELECT
+    a.a_id,
+    a.value * 2 AS value
+FROM
+    (
+        SELECT
+            a.a_id,
+            a.text,
+            b.value
+        FROM
+            table_a AS a
+            INNER JOIN table_b AS b ON a.a_id = b.a_id
+    ) AS a";
+
+        Assert.Equal(sql, sq.ToText(), true, true, true);
+    }
+
     public record struct RecordA(int a_id, string text, int value, bool is_enabled, double rate, DateTime timestamp, Gender gender);
 
     public record struct RecordB(int a_id, int b_id, string text, int value);
 
     public record struct SubQueryRow(int a_id, string text, int value);
-
-    public class Myclass { public int MyProperty { get; set; } }
 
     public enum Gender
     {

--- a/test/Carbunql.Postgres.Test/SubQueryText.cs
+++ b/test/Carbunql.Postgres.Test/SubQueryText.cs
@@ -1,0 +1,171 @@
+﻿using Carbunql.Building;
+using Carbunql.Postgres;
+using Xunit.Abstractions;
+
+namespace Carbunql.Postgres.Test;
+
+public class SubQueryText
+{
+    private readonly QueryCommandMonitor Monitor;
+
+    public SubQueryText(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; set; }
+
+    [Fact]
+    public void FromAs()
+    {
+        var sq = new SelectQuery();
+        var (from, a) = sq.FromAs<RecordA>("a");
+
+        sq.Select("a", "a_id");
+        sq.Select(nameof(a), "a_id");
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.a_id).As("id");
+
+        Monitor.Log(sq);
+
+        var sql = @"SELECT
+    a.a_id,
+    a.a_id,
+    a.a_id,
+    a.a_id AS id
+FROM
+    RecordA AS a";
+
+        Assert.Equal(22, sq.GetTokens().ToList().Count);
+        Assert.Equal(sql.ToValidateText(), sq.ToText().ToValidateText());
+    }
+
+    [Fact]
+    public void AliasAs()
+    {
+        var sq = new SelectQuery();
+        var (from, a) = sq.From("table_a").As<RecordA>("a"); ;
+
+        sq.Select("a", "a_id");
+        sq.Select(nameof(a), "a_id");
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.a_id).As("id");
+
+        Monitor.Log(sq);
+
+        Assert.Equal(22, sq.GetTokens().ToList().Count);
+
+        var sql = @"SELECT
+    a.a_id,
+    a.a_id,
+    a.a_id,
+    a.a_id AS id
+FROM
+    table_a AS a";
+        Assert.Equal(sql, sq.ToText(), true, true, true);
+
+    }
+    [Fact]
+    public void SubQueryTest()
+    {
+        var sq = new SelectQuery();
+        var (from, a) = sq.From(new SelectQuery("select * from table_a")).As<RecordA>("a"); ;
+
+        sq.Select("a", "a_id");
+        sq.Select(nameof(a), "a_id");
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.a_id).As("id");
+
+        Monitor.Log(sq);
+
+        Assert.Equal(27, sq.GetTokens().ToList().Count);
+
+        var sql = @"SELECT
+    a.a_id,
+    a.a_id,
+    a.a_id,
+    a.a_id AS id
+FROM
+    (
+        SELECT
+            *
+        FROM
+            table_a
+    ) AS a";
+        Assert.Equal(sql, sq.ToText(), true, true, true);
+    }
+
+    [Fact]
+    public void SubroutineTest()
+    {
+        var sq = new SelectQuery();
+        var (from, a) = sq.FromAs(GetSelectQuery(), "a");
+
+        sq.Select("a", "a_id");
+        sq.Select(nameof(a), "a_id");
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.a_id).As("id");
+
+        Monitor.Log(sq);
+
+        Assert.Equal(59, sq.GetTokens().ToList().Count);
+
+        var sql = @"SELECT
+    a.a_id,
+    a.a_id,
+    a.a_id,
+    a.a_id AS id
+FROM
+    (
+        SELECT
+            a.a_id,
+            a.text,
+            a.value
+        FROM
+            RecordA AS a
+            INNER JOIN RecordB AS b ON (a.a_id = b.a_id AND b.text = 'test')
+    ) AS a";
+
+        Assert.Equal(sql, sq.ToText(), true, true, true);
+    }
+
+    public SelectQuery<SubQueryRow> GetSelectQuery()
+    {
+        var sq = new SelectQuery<SubQueryRow>();
+        var (from, a) = sq.FromAs<RecordA>("a");
+        var b = from.InnerJoinAs<RecordB>(b => a.a_id == b.a_id && b.text == "test");
+
+        sq.Select(() => a.a_id);
+        sq.Select(() => a.text);
+        sq.Select(() => a.value);
+
+        /*
+SELECT
+    a.a_id,
+    a.text,
+    a.value
+FROM
+    RecordA AS a
+    INNER JOIN RecordB AS b ON (a.a_id = b.a_id AND b.text = 'test')
+         */
+
+        return sq;
+    }
+
+    public record struct RecordA(int a_id, string text, int value, bool is_enabled, double rate, DateTime timestamp, Gender gender);
+
+    public record struct RecordB(int a_id, int b_id, string text, int value);
+
+    public record struct SubQueryRow(int a_id, string text, int value);
+
+    public class Myclass { public int MyProperty { get; set; } }
+
+    public enum Gender
+    {
+        Male,
+        Female,
+        Other,
+        Unknown
+    }
+}


### PR DESCRIPTION
You have to specify the type, but intellisense is available.
The type information is preserved even when converted to a function, which improves the reusability of select queries.