### PR TITLE
Improved the Select clause writing experience

### DIFF
--- a/src/Carbunql.TypeSafe/Sql.cs
+++ b/src/Carbunql.TypeSafe/Sql.cs
@@ -95,29 +95,6 @@ public static class Sql
         return DefineDataSet(expression, Materialized.NotMaterialized);
     }
 
-    public static T DefineSubQuery<T>(SelectQuery query) where T : IDataRow, new()
-    {
-        var instance = new T();
-
-        //var info = TableInfoFactory.Create(typeof(T));
-
-        instance.DataSet = new QueryDataSet(query);
-        return instance;
-    }
-
-    public static T DefineSubQuery<T>(FluentSelectQuery<T> query) where T : IDataRow, new()
-    {
-        var instance = new T();
-
-        instance.DataSet = new QueryDataSet(query);
-        return instance;
-    }
-
-    public static T DefineSubQuery<T>(Func<FluentSelectQuery<T>> builder) where T : IDataRow, new()
-    {
-        return DefineSubQuery<T>(builder.Invoke());
-    }
-
     public static T DefineDataSet<T>() where T : IDataRow, new()
     {
         var instance = new T();

--- a/test/Carbunql.TypeSafe.Test/SelectTest.cs
+++ b/test/Carbunql.TypeSafe.Test/SelectTest.cs
@@ -1,0 +1,146 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.TypeSafe.Test;
+
+public class SelectTest
+{
+    public SelectTest(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; }
+
+    [Fact]
+    public void SelectAllDataSet()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+            .Select(() => od);
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    od.order_id,
+    od.product_id,
+    od.quantity,
+    od.price
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void SelectAllDataSetMultiple()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+        var p = Sql.DefineDataSet<product>();
+
+        var query = Sql.From(() => od)
+            .InnerJoin(() => p, () => od.product_id == p.product_id)
+            .Select(() => od)
+            .Select(() => p);
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    od.order_id,
+    od.product_id,
+    od.quantity,
+    od.price,
+    p.name
+FROM
+    order_detail AS od
+    INNER JOIN product AS p ON od.product_id = p.product_id";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void SelectAllDataSetMultiple_WithAlias()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+        var p = Sql.DefineDataSet<product>();
+
+        var query = Sql.From(() => od)
+            .InnerJoin(() => p, () => od.product_id == p.product_id)
+            .Select(() => od)
+            .Select(() => new
+            {
+                product_price = p.price,
+                product_name = p.name,
+            });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    od.order_id,
+    od.product_id,
+    od.quantity,
+    od.price,
+    p.price AS product_price,
+    p.name AS product_name
+FROM
+    order_detail AS od
+    INNER JOIN product AS p ON od.product_id = p.product_id";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    public record product : IDataRow
+    {
+        public int product_id { get; set; }
+        public string name { get; set; } = string.Empty;
+        public decimal price { get; set; }
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record store : IDataRow
+    {
+        public int store_id { get; set; }
+        public string name { get; set; } = string.Empty;
+        public string location { get; set; } = string.Empty;
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order : IDataRow
+    {
+        public int order_id { get; set; }
+        public DateTime order_date { get; set; }
+        public string customer_name { get; set; } = string.Empty;
+        public int store_id { get; set; }
+        public IList<order_detail> order_details { get; init; } = new List<order_detail>();
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order_detail : IDataRow
+    {
+        public int order_detail_id { get; set; }
+        public int order_id { get; set; }
+        public int product_id { get; set; }
+        public int quantity { get; set; }
+        public decimal price { get; set; }
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order_detail_product : order_detail
+    {
+        public string product_name { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
When an IDataRow is passed to the Select method, it is interpreted as selecting all columns in the dataset.
This is equivalent to the behavior of wildcards in SQL.
Carbunql also allows the Select clause to be written multiple times, so it can be written in a similar way even when joining tables.
If a column to be added has already been registered, it will be ignored.
This is because it is common to write columns with higher priority first.