### PR TITLE
Supports window functions

### DIFF
--- a/src/Carbunql.TypeSafe/Extensions/ExpresionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/ExpresionExtension.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq.Expressions;
+
+namespace Carbunql.TypeSafe.Extensions;
+
+public static class ExpresionExtension
+{
+    public static string ToValue(this Expression exp, Func<string, object?, string> addParameter)
+    {
+        if (exp is MemberExpression mem)
+        {
+            return mem.ToValue(ToValue, addParameter);
+        }
+        else if (exp is ConstantExpression ce)
+        {
+            return ce.ToValue(ToValue, addParameter);
+        }
+        else if (exp is NewExpression ne)
+        {
+            return ne.ToValue(ToValue, addParameter);
+        }
+        else if (exp is BinaryExpression be)
+        {
+            return be.ToValue(ToValue, addParameter);
+        }
+        else if (exp is UnaryExpression ue)
+        {
+            return ue.ToValue(ToValue, addParameter);
+        }
+        else if (exp is MethodCallExpression mce)
+        {
+            return mce.ToValue(ToValue, addParameter);
+        }
+        else if (exp is ConditionalExpression cnd)
+        {
+            return cnd.ToValue(ToValue, addParameter);
+        }
+        else if (exp is ParameterExpression prm)
+        {
+            return prm.ToValue(ToValue, addParameter);
+        }
+
+        throw new InvalidProgramException(exp.ToString());
+    }
+}

--- a/src/Carbunql.TypeSafe/Sql.cs
+++ b/src/Carbunql.TypeSafe/Sql.cs
@@ -153,21 +153,27 @@ public static class Sql
 
     public static DateTime DateTruncateToSecond(DateTime d) => new DateTime();
 
-    public static string RowNumber() => string.Empty;
+    public static int RowNumber() => 0;
 
-    public static string RowNumber(object partition, object order) => string.Empty;
-
-    public static string RowNumberPartitionBy(object partition) => string.Empty;
-
-    public static string RowNumberOrderBy(object order) => string.Empty;
+    public static int RowNumber(Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
 
     public static int Count() => throw new InvalidProgramException();
 
+    public static int Count(Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
+
     public static T Sum<T>(Expression<Func<T>> expression) => throw new InvalidProgramException();
+
+    public static T Sum<T>(Expression<Func<T>> expression, Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
 
     public static T Average<T>(Expression<Func<T>> expression) => throw new InvalidProgramException();
 
+    public static T Average<T>(Expression<Func<T>> expression, Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
+
     public static T Max<T>(Expression<Func<T>> expression) => throw new InvalidProgramException();
 
+    public static T Max<T>(Expression<Func<T>> expression, Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
+
     public static T Min<T>(Expression<Func<T>> expression) => throw new InvalidProgramException();
+
+    public static T Min<T>(Expression<Func<T>> expression, Expression<Func<object?>> partition, Expression<Func<object?>> order) => throw new InvalidProgramException();
 }

--- a/test/Carbunql.TypeSafe.Test/GroupTest.cs
+++ b/test/Carbunql.TypeSafe.Test/GroupTest.cs
@@ -22,11 +22,11 @@ public class GroupTest
                 {
                     od.order_id,
                     total_price = Sql.Sum(() => od.quantity * od.price),
-                    total_amount = Sql.Sum(() => od.quantity),
+                    total_quantity = Sql.Sum(() => od.quantity),
                     count = Sql.Count(),
-                    avg_amount = Sql.Average(() => od.quantity),
-                    min_amount = Sql.Min(() => od.quantity),
-                    max_amount = Sql.Max(() => od.quantity),
+                    avg_quantity = Sql.Average(() => od.quantity),
+                    min_quantity = Sql.Min(() => od.quantity),
+                    max_quantity = Sql.Max(() => od.quantity),
                 })
                 .GroupBy(() => new
                 {
@@ -39,11 +39,11 @@ public class GroupTest
         var expect = @"SELECT
     od.order_id,
     SUM(CAST(od.quantity AS numeric) * od.price) AS total_price,
-    SUM(od.quantity) AS total_amount,
+    SUM(od.quantity) AS total_quantity,
     COUNT(*) AS count,
-    AVG(od.quantity) AS avg_amount,
-    MIN(od.quantity) AS min_amount,
-    MAX(od.quantity) AS max_amount
+    AVG(od.quantity) AS avg_quantity,
+    MIN(od.quantity) AS min_quantity,
+    MAX(od.quantity) AS max_quantity
 FROM
     order_detail AS od
 GROUP BY

--- a/test/Carbunql.TypeSafe.Test/SingleTableTest.cs
+++ b/test/Carbunql.TypeSafe.Test/SingleTableTest.cs
@@ -386,7 +386,7 @@ FROM
     }
 
     [Fact]
-    public void ReservedCommand()
+    public void Now_Timestamp()
     {
         var a = Sql.DefineDataSet<sale>();
 
@@ -395,10 +395,6 @@ FROM
             {
                 now_command = Sql.Now,
                 timestamp_commend = Sql.CurrentTimestamp,
-                row_num = Sql.RowNumber(),
-                row_num_partiton_order = Sql.RowNumber(new { a.product_name, a.unit_price }, new { a.quantity, a.sale_id }),
-                row_num_partition = Sql.RowNumberPartitionBy(new { a.product_name, a.unit_price }),
-                row_num_order = Sql.RowNumberOrderBy(new { a.product_name, a.unit_price })
             });
 
         var actual = query.ToText();
@@ -406,26 +402,7 @@ FROM
 
         var expect = @"SELECT
     CAST(NOW() AS timestamp) AS now_command,
-    current_timestamp AS timestamp_commend,
-    ROW_NUMBER() OVER() AS row_num,
-    ROW_NUMBER() OVER(
-        PARTITION BY
-            a.product_name,
-            a.unit_price
-        ORDER BY
-            a.quantity,
-            a.sale_id
-    ) AS row_num_partiton_order,
-    ROW_NUMBER() OVER(
-        PARTITION BY
-            a.product_name,
-            a.unit_price
-    ) AS row_num_partition,
-    ROW_NUMBER() OVER(
-        ORDER BY
-            a.product_name,
-            a.unit_price
-    ) AS row_num_order
+    current_timestamp AS timestamp_commend
 FROM
     sale AS a";
 

--- a/test/Carbunql.TypeSafe.Test/WindowFunctionTest.cs
+++ b/test/Carbunql.TypeSafe.Test/WindowFunctionTest.cs
@@ -1,0 +1,376 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.TypeSafe.Test;
+
+public class WindowFunctionTest
+{
+    public WindowFunctionTest(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; }
+
+    [Fact]
+    public void RowNumber()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.RowNumber(),
+                    partition_only = Sql.RowNumber(
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.RowNumber(
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.RowNumber(
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    ROW_NUMBER() AS no_argument,
+    ROW_NUMBER() OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    ROW_NUMBER() OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    ROW_NUMBER() OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void Count()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.Count(),
+                    partition_only = Sql.Count(
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.Count(
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.Count(
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    COUNT(*) AS no_argument,
+    COUNT(*) OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    COUNT(*) OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    COUNT(*) OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void Sum()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.Sum(() => od.quantity),
+                    partition_only = Sql.Sum(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.Sum(
+                        () => od.quantity,
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.Sum(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    SUM(od.quantity) AS no_argument,
+    SUM(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    SUM(od.quantity) OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    SUM(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void Min()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.Min(() => od.quantity),
+                    partition_only = Sql.Min(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.Min(
+                        () => od.quantity,
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.Min(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    MIN(od.quantity) AS no_argument,
+    MIN(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    MIN(od.quantity) OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    MIN(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void Max()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.Max(() => od.quantity),
+                    partition_only = Sql.Max(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.Max(
+                        () => od.quantity,
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.Max(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    MAX(od.quantity) AS no_argument,
+    MAX(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    MAX(od.quantity) OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    MAX(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void Average()
+    {
+        var od = Sql.DefineDataSet<order_detail>();
+
+        var query = Sql.From(() => od)
+                .Select(() => new
+                {
+                    od.order_detail_id,
+                    no_argument = Sql.Average(() => od.quantity),
+                    partition_only = Sql.Average(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => null
+                    ),
+                    order_only = Sql.Average(
+                        () => od.quantity,
+                        () => null,
+                        () => new { od.order_detail_id }
+                    ),
+                    partition_order = Sql.Average(
+                        () => od.quantity,
+                        () => new { od.order_id },
+                        () => new { od.order_detail_id }
+                    ),
+                });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    od.order_detail_id,
+    AVG(od.quantity) AS no_argument,
+    AVG(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+    ) AS partition_only,
+    AVG(od.quantity) OVER(
+        ORDER BY
+            od.order_detail_id
+    ) AS order_only,
+    AVG(od.quantity) OVER(
+        PARTITION BY
+            od.order_id
+        ORDER BY
+            od.order_detail_id
+    ) AS partition_order
+FROM
+    order_detail AS od";
+
+        Assert.Equal(expect, actual, true, true, true);
+
+    }
+    public record product : IDataRow
+    {
+        public int product_id { get; set; }
+        public string name { get; set; } = string.Empty;
+        public decimal price { get; set; }
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record store : IDataRow
+    {
+        public int store_id { get; set; }
+        public string name { get; set; } = string.Empty;
+        public string location { get; set; } = string.Empty;
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order : IDataRow
+    {
+        public int order_id { get; set; }
+        public DateTime order_date { get; set; }
+        public string customer_name { get; set; } = string.Empty;
+        public int store_id { get; set; }
+        public IList<order_detail> order_details { get; init; } = new List<order_detail>();
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order_detail : IDataRow
+    {
+        public int order_detail_id { get; set; }
+        public int order_id { get; set; }
+        public int product_id { get; set; }
+        public int quantity { get; set; }
+        public decimal price { get; set; }
+
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+    public record order_detail_report : order_detail
+    {
+        public DateTime order_date { get; set; }
+        public string customer_name { get; set; } = string.Empty;
+        public int store_id { get; set; }
+    }
+}


### PR DESCRIPTION
Argument format has been unified.
Partition and order cannot be omitted. If you want to omit them, you must explicitly specify NULL.