### PR TITLE
Changes to name conversion rules

### DIFF
--- a/src/Carbunql.TypeSafe/Carbunql.TypeSafe.csproj
+++ b/src/Carbunql.TypeSafe/Carbunql.TypeSafe.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
-		<Version>0.0.2</Version>
+		<Version>0.0.3</Version>
 		<Authors>mk3008net</Authors>
 		<Description>This library allows for TypeSafe SQL building, enables independent definition and reuse of subqueries and CTEs, and supports unit testing without the need for tables.</Description>
 		<Copyright>mk3008net</Copyright>

--- a/src/Carbunql.TypeSafe/Extensions/BinaryExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/BinaryExpressionExtension.cs
@@ -7,11 +7,10 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class BinaryExpressionExtension
 {
     internal static string ToValue(this BinaryExpression be
-       , Func<Expression, Func<string, object?, string>, string> mainConverter
        , Func<string, object?, string> addParameter)
     {
-        var left = mainConverter(be.Left, addParameter);
-        var right = mainConverter(be.Right, addParameter);
+        var left = be.Left.ToValue(addParameter);
+        var right = be.Right.ToValue(addParameter);
         return ToValue(be.NodeType, left, right);
     }
 

--- a/src/Carbunql.TypeSafe/Extensions/ConditionalExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/ConditionalExpressionExtension.cs
@@ -6,12 +6,11 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class ConditionalExpressionExtension
 {
     internal static string ToValue(this ConditionalExpression cnd
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
-        var test = mainConverter(cnd.Test, addParameter);
-        var ifTrue = mainConverter(cnd.IfTrue, addParameter);
-        var ifFalse = mainConverter(cnd.IfFalse, addParameter);
+        var test = cnd.Test.ToValue(addParameter);
+        var ifTrue = cnd.IfTrue.ToValue(addParameter);
+        var ifFalse = cnd.IfFalse.ToValue(addParameter);
 
         if (string.IsNullOrEmpty(ifFalse))
         {

--- a/src/Carbunql.TypeSafe/Extensions/ConstantExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/ConstantExpressionExtension.cs
@@ -5,7 +5,6 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class ConstantExpressionExtension
 {
     internal static string ToValue(this ConstantExpression ce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         var obj = ce.Value;

--- a/src/Carbunql.TypeSafe/Extensions/ExpresionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/ExpresionExtension.cs
@@ -8,35 +8,35 @@ public static class ExpresionExtension
     {
         if (exp is MemberExpression mem)
         {
-            return mem.ToValue(ToValue, addParameter);
+            return mem.ToValue(addParameter);
         }
         else if (exp is ConstantExpression ce)
         {
-            return ce.ToValue(ToValue, addParameter);
+            return ce.ToValue(addParameter);
         }
         else if (exp is NewExpression ne)
         {
-            return ne.ToValue(ToValue, addParameter);
+            return ne.ToValue(addParameter);
         }
         else if (exp is BinaryExpression be)
         {
-            return be.ToValue(ToValue, addParameter);
+            return be.ToValue(addParameter);
         }
         else if (exp is UnaryExpression ue)
         {
-            return ue.ToValue(ToValue, addParameter);
+            return ue.ToValue(addParameter);
         }
         else if (exp is MethodCallExpression mce)
         {
-            return mce.ToValue(ToValue, addParameter);
+            return mce.ToValue(addParameter);
         }
         else if (exp is ConditionalExpression cnd)
         {
-            return cnd.ToValue(ToValue, addParameter);
+            return cnd.ToValue(addParameter);
         }
         else if (exp is ParameterExpression prm)
         {
-            return prm.ToValue(ToValue, addParameter);
+            return prm.ToValue(addParameter);
         }
 
         throw new InvalidProgramException(exp.ToString());

--- a/src/Carbunql.TypeSafe/Extensions/MemberExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/MemberExpressionExtension.cs
@@ -5,7 +5,6 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class MemberExpressionExtension
 {
     internal static string ToValue(this MemberExpression mem
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         var tp = mem.Member.DeclaringType;
@@ -18,8 +17,10 @@ internal static class MemberExpressionExtension
         if (mem.Expression is MemberExpression && typeof(IDataRow).IsAssignableFrom(tp))
         {
             //column
-            var table = ((MemberExpression)mem.Expression).Member.Name;
+            var tableMember = (MemberExpression)mem.Expression;
+            var table = tableMember.Member.Name;
             var column = mem.Member.Name;
+
             return $"{table}.{column}";
         }
         if (mem.Expression is ConstantExpression ce)
@@ -29,7 +30,7 @@ internal static class MemberExpressionExtension
         }
         if (mem.Expression is MemberExpression me)
         {
-            return me.ToValue(mainConverter, addParameter);
+            return me.ToValue(addParameter);
         }
         if (mem.Expression is ParameterExpression pe)
         {

--- a/src/Carbunql.TypeSafe/Extensions/MethodCallExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/MethodCallExpressionExtension.cs
@@ -12,45 +12,43 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class MethodCallExpressionExtension
 {
     internal static string ToValue(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         // DeclaringType
         if (mce.Method.DeclaringType == typeof(Math))
         {
-            return CreateMathCommand(mce, mainConverter, addParameter);
+            return CreateMathCommand(mce, addParameter);
         }
         if (mce.Method.DeclaringType == typeof(Sql))
         {
-            return CreateSqlCommand(mce, mainConverter, addParameter);
+            return CreateSqlCommand(mce, addParameter);
         }
         if (mce.Method.DeclaringType == typeof(DateTimeExtension))
         {
-            return CreateDateTimeExtensionCommand(mce, mainConverter, addParameter);
+            return CreateDateTimeExtensionCommand(mce, addParameter);
         }
 
         // Return Type
         if (mce.Type == typeof(string))
         {
-            return ToStringValue(mce, mainConverter, addParameter);
+            return ToStringValue(mce, addParameter);
         }
         if (mce.Type == typeof(bool))
         {
-            return ToBoolValue(mce, mainConverter, addParameter);
+            return ToBoolValue(mce, addParameter);
         }
         if (mce.Type == typeof(DateTime))
         {
-            return ToDateTimeValue(mce, mainConverter, addParameter);
+            return ToDateTimeValue(mce, addParameter);
         }
 
         throw new NotSupportedException($"Type:{mce.Type}, Method.DeclaringType:{mce.Method.DeclaringType}");
     }
 
     private static string CreateMathCommand(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
-        var args = mce.Arguments.Select(x => RemoveRootBracketOrDefault(mainConverter(x, addParameter)));
+        var args = mce.Arguments.Select(x => RemoveRootBracketOrDefault(x.ToValue(addParameter)));
 
         return mce.Method.Name switch
         {
@@ -63,34 +61,33 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string CreateDateTimeExtensionCommand(MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         switch (mce.Method.Name)
         {
             case nameof(DateTimeExtension.TruncateToYear):
-                return $"date_trunc('year', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('year', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToQuarter):
-                return $"date_trunc('quarter', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('quarter', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToMonth):
-                return $"date_trunc('month', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('month', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToDay):
-                return $"date_trunc('day', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('day', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToHour):
-                return $"date_trunc('hour', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('hour',{mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToMinute):
-                return $"date_trunc('minute', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('minute', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.TruncateToSecond):
-                return $"date_trunc('second', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('second', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(DateTimeExtension.ToMonthEndDate):
-                return $"date_trunc('month', {mainConverter(mce.Arguments[0], addParameter)}) + interval '1 month - 1 day'";
+                return $"date_trunc('month', {mce.Arguments[0].ToValue(addParameter)}) + interval '1 month - 1 day'";
 
             default:
                 throw new ArgumentException($"Unsupported method call: {mce.Method.Name}");
@@ -100,31 +97,30 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string CreateSqlCommand(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         switch (mce.Method.Name)
         {
             case nameof(Sql.DateTruncateToYear):
-                return $"date_trunc('year', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('year', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncateToQuarter):
-                return $"date_trunc('quarter', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('quarter', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncToMonth):
-                return $"date_trunc('month', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('month', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncateToDay):
-                return $"date_trunc('day', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('day', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncateToHour):
-                return $"date_trunc('hour', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('hour', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncateToMinute):
-                return $"date_trunc('minute', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('minute', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.DateTruncateToSecond):
-                return $"date_trunc('second', {mainConverter(mce.Arguments[0], addParameter)})";
+                return $"date_trunc('second', {mce.Arguments[0].ToValue(addParameter)})";
 
             case nameof(Sql.Raw):
                 if (mce.Arguments.First() is ConstantExpression argRaw)
@@ -134,7 +130,7 @@ internal static class MethodCallExpressionExtension
                 break;
 
             case nameof(Sql.RowNumber):
-                return Aggregate(mce, mainConverter, addParameter, "row_number");
+                return Aggregate(mce, addParameter, "row_number");
 
 
             case nameof(Sql.Exists):
@@ -142,17 +138,17 @@ internal static class MethodCallExpressionExtension
                 return ToExistsClause(mce);
 
             case nameof(Sql.Sum):
-                return Aggregate(mce, mainConverter, addParameter, "sum");
+                return Aggregate(mce, addParameter, "sum");
 
             case nameof(Sql.Count):
-                return Aggregate(mce, mainConverter, addParameter, "count");
+                return Aggregate(mce, addParameter, "count");
 
             case nameof(Sql.Min):
-                return Aggregate(mce, mainConverter, addParameter, "min");
+                return Aggregate(mce, addParameter, "min");
             case nameof(Sql.Max):
-                return Aggregate(mce, mainConverter, addParameter, "max");
+                return Aggregate(mce, addParameter, "max");
             case nameof(Sql.Average):
-                return Aggregate(mce, mainConverter, addParameter, "avg");
+                return Aggregate(mce, addParameter, "avg");
 
             default:
                 throw new ArgumentException($"Unsupported method call: {mce.Method.Name}");
@@ -162,9 +158,8 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string Aggregate(MethodCallExpression mce
-    , Func<Expression, Func<string, object?, string>, string> mainConverter
-    , Func<string, object?, string> addParameter
-    , string aggregateFunction)
+        , Func<string, object?, string> addParameter
+        , string aggregateFunction)
     {
 #if DEBUG
         // Analyze the expression tree for debugging purposes
@@ -183,7 +178,7 @@ internal static class MethodCallExpressionExtension
         }
         else
         {
-            value = ExtractFunction(mce, mainConverter, addParameter, aggregateFunction, mce.Arguments[0]);
+            value = ExtractFunction(mce, addParameter, aggregateFunction, mce.Arguments[0]);
         }
 
         // Determine the argument indices for partition and order
@@ -195,8 +190,8 @@ internal static class MethodCallExpressionExtension
         // - Main function argument, partition, order
         // - Partition, order
         // There are no functions that only have a partition or only have an order.
-        string partitionby = mce.Arguments.Count <= partitionArgumentIndex ? string.Empty : ExtractPartition(mce, mainConverter, addParameter, mce.Arguments[partitionArgumentIndex]);
-        string orderby = mce.Arguments.Count <= orderArgumentIndex ? string.Empty : ExtractOrder(mce, mainConverter, addParameter, mce.Arguments[orderArgumentIndex]);
+        string partitionby = mce.Arguments.Count <= partitionArgumentIndex ? string.Empty : ExtractPartition(mce, addParameter, mce.Arguments[partitionArgumentIndex]);
+        string orderby = mce.Arguments.Count <= orderArgumentIndex ? string.Empty : ExtractOrder(mce, addParameter, mce.Arguments[orderArgumentIndex]);
 
         // Construct the final SQL function string with the over clause
         if (!string.IsNullOrEmpty(partitionby) && !string.IsNullOrEmpty(orderby))
@@ -216,7 +211,6 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ExtractFunction(MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter
         , string functionName
         , Expression? argument)
@@ -228,12 +222,12 @@ internal static class MethodCallExpressionExtension
 
         if (expression.Body is BinaryExpression be)
         {
-            var value = be.ToValue(mainConverter, addParameter);
+            var value = be.ToValue(addParameter);
             return $"{functionName}({value})";
         }
         if (expression.Body is MemberExpression me)
         {
-            var value = me.ToValue(mainConverter, addParameter);
+            var value = me.ToValue(addParameter);
             return $"{functionName}({value})";
         }
 
@@ -241,9 +235,8 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ExtractPartition(MethodCallExpression mce
-     , Func<Expression, Func<string, object?, string>, string> mainConverter
-     , Func<string, object?, string> addParameter
-     , Expression argument)
+        , Func<string, object?, string> addParameter
+        , Expression argument)
     {
 #if DEBUG
         // Analyze the expression tree for debugging purposes
@@ -267,7 +260,6 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ExtractOrder(MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter
         , Expression argument)
     {
@@ -329,12 +321,11 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ToStringValue(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         if (mce.Object != null)
         {
-            var value = mainConverter(mce.Object, addParameter);
+            var value = mce.Object.ToValue(addParameter);
             if (mce.Arguments.Count == 0)
             {
                 if (mce.Method.Name == nameof(String.TrimStart))
@@ -364,11 +355,11 @@ internal static class MethodCallExpressionExtension
                         var v = ConverToDbDateFormat(value!.ToString()!);
                         return addParameter(key, v);
                     };
-                    var typedArg = mainConverter(mce.Arguments[0], typeCaster);
+                    var typedArg = mce.Arguments[0].ToValue(typeCaster);
                     return $"to_char({value}, {typedArg})";
                 }
 
-                var arg = mainConverter(mce.Arguments[0], addParameter);
+                var arg = mce.Arguments[0].ToValue(addParameter);
                 if (mce.Method.Name == nameof(String.StartsWith))
                 {
                     return $"{value} like {arg} || '%'";
@@ -390,7 +381,6 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ToBoolValue(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         if (mce.Object != null)
@@ -399,9 +389,9 @@ internal static class MethodCallExpressionExtension
             {
                 if (mce.Method.DeclaringType == typeof(string))
                 {
-                    var value = mainConverter(mce.Object, addParameter);
+                    var value = mce.Object.ToValue(addParameter);
 
-                    var arg = mainConverter(mce.Arguments[0], addParameter);
+                    var arg = mce.Arguments[0].ToValue(addParameter);
                     if (mce.Method.Name == nameof(String.StartsWith))
                     {
                         return $"{value} like {arg} || '%'";
@@ -432,9 +422,9 @@ internal static class MethodCallExpressionExtension
                         return string.Empty;
                     };
 
-                    _ = mainConverter(mce.Object, argumentsDecoder);
+                    _ = mce.Object.ToValue(argumentsDecoder);
 
-                    var left = mainConverter(mce.Arguments[0], addParameter);
+                    var left = mce.Arguments[0].ToValue(addParameter);
                     if (mce.Method.Name == nameof(String.Contains))
                     {
                         return $"{left} in({string.Join(",", args)})";
@@ -452,7 +442,7 @@ internal static class MethodCallExpressionExtension
                 {
                     if (mce.Method.Name == nameof(Enumerable.Any))
                     {
-                        return ToAnyClauseValue(mce, mainConverter, addParameter);
+                        return ToAnyClauseValue(mce, addParameter);
                     }
                 }
             }
@@ -461,7 +451,6 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ToAnyClauseValue(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         // Format:
@@ -472,7 +461,7 @@ internal static class MethodCallExpressionExtension
         var lambda = (LambdaExpression)mce.Arguments[1];
         var variableName = lambda.Parameters[0].Name!;
 
-        var arrayParameterName = mainConverter(mce.Arguments[0], addParameter);
+        var arrayParameterName = mce.Arguments[0].ToValue(addParameter);
 
         // Hook the parameter name and return in the format any(PARAMETER)
         var hasAnyCommand = false;
@@ -490,13 +479,13 @@ internal static class MethodCallExpressionExtension
         if (body.NodeType != ExpressionType.Equal) throw new InvalidProgramException();
 
         // Adjust to make the ANY function appear on the right side
-        var left = mainConverter(body.Left, interceptor);
+        var left = body.Left.ToValue(interceptor);
         if (hasAnyCommand)
         {
-            return $"{mainConverter(body.Right, interceptor)} = {left}";
+            return $"{body.Right.ToValue(interceptor)} = {left}";
         }
 
-        var right = mainConverter(body.Right, interceptor);
+        var right = body.Right.ToValue(interceptor);
         if (hasAnyCommand)
         {
             return $"{left} = {right}";
@@ -506,16 +495,15 @@ internal static class MethodCallExpressionExtension
     }
 
     private static string ToDateTimeValue(this MethodCallExpression mce
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         if (mce!.Object != null)
         {
-            var value = mainConverter(mce!.Object!, addParameter);
+            var value = mce!.Object!.ToValue(addParameter);
 
             if (mce.Arguments.Count == 1)
             {
-                var arg = mainConverter(mce.Arguments[0], addParameter);
+                var arg = mce.Arguments[0].ToValue(addParameter);
 
                 if (mce.Method.Name == nameof(DateTime.AddYears))
                 {
@@ -554,7 +542,7 @@ internal static class MethodCallExpressionExtension
             if (mce.Arguments.Count == 1)
             {
                 Func<string, object?, string> echo = (_, x) => x!.ToString()!;
-                return mce.ToValue(mainConverter, echo);
+                return mce.ToValue(echo);
             }
 
             throw new NotSupportedException($"Object:NULL, Method:{mce.Method.Name}, Arguments:{mce.Arguments.Count}, Type:{mce.Type}");

--- a/src/Carbunql.TypeSafe/Extensions/NewExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/NewExpressionExtension.cs
@@ -5,7 +5,6 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class NewExpressionExtension
 {
     internal static string ToValue(this NewExpression ne
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         var obj = ne.CompileAndInvoke();

--- a/src/Carbunql.TypeSafe/Extensions/UnaryExpressionExtension.cs
+++ b/src/Carbunql.TypeSafe/Extensions/UnaryExpressionExtension.cs
@@ -5,21 +5,19 @@ namespace Carbunql.TypeSafe.Extensions;
 internal static class UnaryExpressionExtension
 {
     internal static string ToValue(this UnaryExpression ue
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
         if (ue.NodeType == ExpressionType.Convert)
         {
-            return ToConvertValue(ue, mainConverter, addParameter);
+            return ToConvertValue(ue, addParameter);
         }
         throw new InvalidProgramException($"NodeType:{ue.NodeType}");
     }
 
     private static string ToConvertValue(UnaryExpression ue
-        , Func<Expression, Func<string, object?, string>, string> mainConverter
         , Func<string, object?, string> addParameter)
     {
-        var value = mainConverter(ue.Operand, addParameter);
+        var value = ue.Operand.ToValue(addParameter);
         return FluentSelectQuery.CreateCastStatement(value, ue.Type);
     }
 }

--- a/src/Carbunql.TypeSafe/FluentSelectQuery.cs
+++ b/src/Carbunql.TypeSafe/FluentSelectQuery.cs
@@ -117,32 +117,6 @@ public class FluentSelectQuery : SelectQuery
         return this;
     }
 
-    private FluentSelectQuery Aggregate<T>(Expression<Func<T>> expression, string aggregateFunction) where T : class
-    {
-#if DEBUG
-        var analyzed = ExpressionReader.Analyze(expression);
-#endif
-        var mergedParameter = QueryParameterMerger.Merge(GetParameters());
-
-        var prmManager = new ParameterManager(mergedParameter, AddParameter);
-
-        if (expression.Body is NewExpression ne)
-        {
-            if (ne.Members != null)
-            {
-                var cnt = ne.Members.Count();
-                for (var i = 0; i < cnt; i++)
-                {
-                    var alias = ne.Members[i].Name;
-                    var value = ne.Arguments[i].ToValue(prmManager.AddParameter);
-                    this.Select($"{aggregateFunction}({value})").As(alias);
-                }
-                return this;
-            }
-        }
-        throw new InvalidProgramException();
-    }
-
     public FluentSelectQuery GroupBy<T>(Expression<Func<T>> expression) where T : class
     {
 #if DEBUG
@@ -203,6 +177,7 @@ public class FluentSelectQuery : SelectQuery
         var table = compiledExpression();
 
         var prmManager = new ParameterManager(GetParameters(), AddParameter);
+
         var condition = conditionExpression.Body.ToValue(prmManager.AddParameter);
 
         table.DataSet.BuildJoinClause(this, "left join", tableAlias, condition);
@@ -223,6 +198,7 @@ public class FluentSelectQuery : SelectQuery
         var table = compiledExpression();
 
         var prmManager = new ParameterManager(GetParameters(), AddParameter);
+
         var condition = conditionExpression.Body.ToValue(prmManager.AddParameter);
 
         table.DataSet.BuildJoinClause(this, "right join", tableAlias, condition);
@@ -265,6 +241,7 @@ public class FluentSelectQuery : SelectQuery
         var analyzed = ExpressionReader.Analyze(expression);
 #endif
         var prmManager = new ParameterManager(GetParameters(), AddParameter);
+
         var value = expression.Body.ToValue(prmManager.AddParameter);
 
         var clause = TableDefinitionClauseFactory.Create<T>();
@@ -284,6 +261,7 @@ public class FluentSelectQuery : SelectQuery
         var analyzed = ExpressionReader.Analyze(expression);
 #endif
         var prmManager = new ParameterManager(GetParameters(), AddParameter);
+
         var value = expression.Body.ToValue(prmManager.AddParameter);
 
         var clause = TableDefinitionClauseFactory.Create<T>();
@@ -305,6 +283,7 @@ public class FluentSelectQuery : SelectQuery
         var analyzed = ExpressionReader.Analyze(expression);
 #endif
         var prmManager = new ParameterManager(GetParameters(), AddParameter);
+
         var value = expression.Body.ToValue(prmManager.AddParameter);
 
         var fsql = new SelectQuery();

--- a/src/Carbunql.TypeSafe/Sql.cs
+++ b/src/Carbunql.TypeSafe/Sql.cs
@@ -111,9 +111,16 @@ public static class Sql
 
     public static T DefineDataSet<T>() where T : IDataRow, new()
     {
+        var atr = (TableAttribute?)Attribute.GetCustomAttribute(typeof(T), typeof(TableAttribute));
+
+        var schema = string.IsNullOrEmpty(atr?.Schema) ? string.Empty : atr.Schema;
+        var table = string.IsNullOrEmpty(atr?.Table) ? typeof(T).Name : atr.Table;
+        var info = new TableInfo(table) { Schema = schema };
+
+        var columnNames = PropertySelector.SelectLiteralProperties<T>().Select(x => x.Name);
+
         var instance = new T();
-        var clause = TableDefinitionClauseFactory.Create<T>();
-        instance.DataSet = new PhysicalTableDataSet(clause, clause.GetColumnNames());
+        instance.DataSet = new PhysicalTableDataSet(info, columnNames);
         return instance;
     }
 

--- a/src/Carbunql/Annotations/PropertySelector.cs
+++ b/src/Carbunql/Annotations/PropertySelector.cs
@@ -36,9 +36,14 @@ public class PropertySelector
     /// <returns>An enumerable of PropertyInfo representing the selected properties.</returns>
     public static IEnumerable<PropertyInfo> SelectLiteralProperties<T>()
     {
+        return SelectLiteralProperties(typeof(T));
+    }
+
+    public static IEnumerable<PropertyInfo> SelectLiteralProperties(Type type)
+    {
         // Exclude properties with invalid attributes.
         // Exclude properties with non-literal types.
-        var props = SelectProperties<T>()
+        var props = SelectProperties(type)
             .Where(prop => LiteralTypes.Contains(prop.PropertyType));
 
         return props;
@@ -70,8 +75,13 @@ public class PropertySelector
     /// <returns>An enumerable of PropertyInfo representing the selected properties.</returns>
     private static IEnumerable<PropertyInfo> SelectProperties<T>()
     {
+        return SelectProperties(typeof(T));
+    }
+
+    private static IEnumerable<PropertyInfo> SelectProperties(Type type)
+    {
         // Exclude properties with invalid attributes.
-        var props = typeof(T).GetProperties()
+        var props = type.GetProperties()
             .Where(prop => !Attribute.IsDefined(prop, typeof(IgnoreMappingAttribute)));
 
         return props;

--- a/test/Carbunql.TypeSafe.Test/ModelNameFormatTest.cs
+++ b/test/Carbunql.TypeSafe.Test/ModelNameFormatTest.cs
@@ -1,0 +1,85 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.TypeSafe.Test;
+
+public class ModelNameFormatTest
+{
+
+    public ModelNameFormatTest(ITestOutputHelper output)
+    {
+        Output = output;
+    }
+
+    private ITestOutputHelper Output { get; }
+
+    [Fact]
+    public void SnakeCase_OmitSelectClause()
+    {
+        var sd = Sql.DefineDataSet<StoreData>();
+
+        var query = Sql.From(() => sd);
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    *
+FROM
+    store_data AS sd";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void SnakeCase_SelectAll()
+    {
+        var sd = Sql.DefineDataSet<StoreData>();
+
+        var query = Sql.From(() => sd)
+            .Select(() => sd);
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    sd.store_data_id,
+    sd.store_name
+FROM
+    store_data AS sd";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void SnakeCase_SelectColumn()
+    {
+        var sd = Sql.DefineDataSet<StoreData>();
+
+        var query = Sql.From(() => sd)
+            .Select(() => new
+            {
+                sd.StoreDataId,
+                sd.StoreName,
+            });
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    sd.store_data_id,
+    sd.store_name
+FROM
+    store_data AS sd";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    public record StoreData : IDataRow
+    {
+        public int StoreDataId { get; set; }
+        public string StoreName { get; set; } = string.Empty;
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
+
+}

--- a/test/Carbunql.TypeSafe.Test/ModelNameFormatTest.cs
+++ b/test/Carbunql.TypeSafe.Test/ModelNameFormatTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit.Abstractions;
+﻿using Carbunql.Annotations;
+using Xunit.Abstractions;
 
 namespace Carbunql.TypeSafe.Test;
 
@@ -13,7 +14,7 @@ public class ModelNameFormatTest
     private ITestOutputHelper Output { get; }
 
     [Fact]
-    public void SnakeCase_OmitSelectClause()
+    public void OmitSelectClause()
     {
         var sd = Sql.DefineDataSet<StoreData>();
 
@@ -25,13 +26,13 @@ public class ModelNameFormatTest
         var expect = @"SELECT
     *
 FROM
-    store_data AS sd";
+    StoreData AS sd";
 
         Assert.Equal(expect, actual, true, true, true);
     }
 
     [Fact]
-    public void SnakeCase_SelectAll()
+    public void SelectAll()
     {
         var sd = Sql.DefineDataSet<StoreData>();
 
@@ -42,16 +43,16 @@ FROM
         Output.WriteLine(actual);
 
         var expect = @"SELECT
-    sd.store_data_id,
-    sd.store_name
+    sd.StoreDataId,
+    sd.StoreName
 FROM
-    store_data AS sd";
+    StoreData AS sd";
 
         Assert.Equal(expect, actual, true, true, true);
     }
 
     [Fact]
-    public void SnakeCase_SelectColumn()
+    public void SelectColumn()
     {
         var sd = Sql.DefineDataSet<StoreData>();
 
@@ -66,10 +67,28 @@ FROM
         Output.WriteLine(actual);
 
         var expect = @"SELECT
-    sd.store_data_id,
-    sd.store_name
+    sd.StoreDataId,
+    sd.StoreName
 FROM
-    store_data AS sd";
+    StoreData AS sd";
+
+        Assert.Equal(expect, actual, true, true, true);
+    }
+
+    [Fact]
+    public void TableNameFromAttribute()
+    {
+        var s = Sql.DefineDataSet<Store>();
+
+        var query = Sql.From(() => s);
+
+        var actual = query.ToText();
+        Output.WriteLine(actual);
+
+        var expect = @"SELECT
+    *
+FROM
+    public.stores AS s";
 
         Assert.Equal(expect, actual, true, true, true);
     }
@@ -82,4 +101,12 @@ FROM
         IDataSet IDataRow.DataSet { get; set; } = null!;
     }
 
+    [Table([nameof(store_id)], Schema = "public", Table = "stores")]
+    public record Store : IDataRow
+    {
+        public int store_id { get; set; }
+        public string store_name { get; set; } = string.Empty;
+        // interface property
+        IDataSet IDataRow.DataSet { get; set; } = null!;
+    }
 }


### PR DESCRIPTION
Table names can be specified by attributes, but column names must be the same as property names.
Reason:
Because it is unclear how to handle property names of anonymous classes.