### PR TITLE
Changed the specification of the With clause injection method

### DIFF
--- a/src/Carbunql.TypeSafe/Carbunql.TypeSafe.csproj
+++ b/src/Carbunql.TypeSafe/Carbunql.TypeSafe.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>12.0</LangVersion>
-		<Version>0.0.3</Version>
+		<Version>0.0.4</Version>
 		<Authors>mk3008net</Authors>
 		<Description>This library allows for TypeSafe SQL building, enables independent definition and reuse of subqueries and CTEs, and supports unit testing without the need for tables.</Description>
 		<Copyright>mk3008net</Copyright>


### PR DESCRIPTION
If there are no duplicate names, they will be added to the beginning. If there are duplicate names, the behavior can be changed by arguments (overwrite or error)