### PR TITLE
Change the output location of the comment clause

### DIFF
--- a/demo/TypeSafeBuild/Program.cs
+++ b/demo/TypeSafeBuild/Program.cs
@@ -34,6 +34,7 @@ internal class Program
         // Debug
         var query = SelectSaleReportQuery();
         var sale = SelectSaleTestDataQuery();
+        query.AddHeaderComment("unit test query");
         query.With(() => sale);
 
         Console.WriteLine(query.ToText());

--- a/src/Carbunql.TypeSafe/FluentSelectQuery.cs
+++ b/src/Carbunql.TypeSafe/FluentSelectQuery.cs
@@ -406,6 +406,7 @@ public class FluentSelectQuery : SelectQuery
         q.LimitClause = LimitClause;
         q.Parameters = Parameters;
         q.CommentClause = CommentClause;
+        q.HeaderCommentClause = HeaderCommentClause;
 
         var clause = TableDefinitionClauseFactory.Create<T>();
 

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.8.0</Version>
+		<Version>0.8.1</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -102,18 +102,19 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
     /// <inheritdoc/>
     public override IEnumerable<Token> GetCurrentTokens(Token? parent)
     {
-        if (CommentClause != null)
+        if (parent == null && WithClause != null)
         {
-            foreach (var item in CommentClause.GetTokens(parent))
+            var commonTables = GetCommonTables();
+            foreach (var item in WithClause.GetTokens(parent, commonTables))
             {
                 yield return item;
             }
         }
 
-        if (parent == null && WithClause != null)
+        // Comments will be unified to be displayed just before the selected section.
+        if (CommentClause != null)
         {
-            var commonTables = GetCommonTables();
-            foreach (var item in WithClause.GetTokens(parent, commonTables))
+            foreach (var item in CommentClause.GetTokens(parent))
             {
                 yield return item;
             }

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -94,14 +94,44 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
     public WindowClause? WindowClause { get; set; }
 
     /// <summary>
-    /// Gets or sets the comment clause of the select query.
+    /// Gets or sets the comment clause of the select clause.
     /// </summary>
+    /// <remarks>
+    /// A comment that is output before the selection clause. It is suitable for indicating the nature of the selection query.
+    /// Since it is output after the With clause, it is less visible than the HeaderCommentClause.
+    /// </remarks>
     [IgnoreMember]
     public CommentClause? CommentClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the comment clause for the select query.
+    /// This is printed before the With clause, which can be useful for debugging.
+    /// </summary>
+    /// <remarks>
+    /// This is printed before the With clause and is useful for debugging.
+    /// However, it is not printed if it is not the root query.
+    /// </remarks>
+    [IgnoreMember]
+    public CommentClause? HeaderCommentClause { get; set; }
+
+    public void AddHeaderComment(string comment)
+    {
+        HeaderCommentClause ??= new CommentClause();
+        HeaderCommentClause.Add(comment);
+    }
 
     /// <inheritdoc/>
     public override IEnumerable<Token> GetCurrentTokens(Token? parent)
     {
+        // If this is a root query, a header comment is printed on the first line.
+        if (parent == null && HeaderCommentClause != null)
+        {
+            foreach (var item in HeaderCommentClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
         if (parent == null && WithClause != null)
         {
             var commonTables = GetCommonTables();


### PR DESCRIPTION
## Before change
Comment lines are displayed with priority over the WITH clause.

## After change
Comments are displayed immediately before the SELECT clause.
They are displayed after the WITH clause.
For comments that you want to display with priority over the WITH clause, use the newly created HeaderComment clause.

## Reason
Comments are intended for select queries.
For this reason, if comments are displayed before the WITH clause, the comment content and the processing content will be separated, making it difficult to understand.

## Response
Current comments have been changed to be displayed immediately before the SELECT clause.
However, there are cases where you want to leave a comment for the entire query, so in such cases use HeaderComment.