### PR TITLE
The IQuerySource interface has been redefined.

### DIFF
--- a/demo/CarbunqlWeb/Pages/QuerySource/Labels.razor
+++ b/demo/CarbunqlWeb/Pages/QuerySource/Labels.razor
@@ -88,11 +88,7 @@ Console.WriteLine(q.ToText());";
 
             q.GetQuerySources().ForEach(x =>
             {
-                x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Index:{x.SourceIndex}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-            })
-            .GetRootsBySource().OrderBy(x => x.SourceIndex).ForEach(x =>
-            {
-                x.AddQueryComment($"Root:{string.Join("-", x.ReferencedIndexes)}");
+                x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
             });
 
             fsql = q.ToText();

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.8.3</Version>
+		<Version>0.8.4</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/IEnumerableExtension.cs
+++ b/src/Carbunql/IEnumerableExtension.cs
@@ -20,12 +20,9 @@ public static class IEnumerableExtension
     public static IEnumerable<T> GetRootsBySource<T>(this IEnumerable<T> source) where T : IQuerySource
     {
         var sources = new List<T>();
-        foreach (var item in (from x in source orderby x.Level descending, x.ParentIndex descending, x.SourceIndex select x))
+        foreach (var item in (from x in source orderby x.MaxLevel descending, x.Index select x))
         {
-            if (!sources.Where(x => x.ReferencedIndexes.Contains(item.SourceIndex)).Any())
-            {
-                sources.Add(item);
-            }
+            sources.Add(item);
         }
         return sources;
     }
@@ -38,7 +35,7 @@ public static class IEnumerableExtension
     /// <returns>A collection of QuerySources, one per query, ordered by descending Level and ascending Sequence.</returns>
     public static IEnumerable<T> GetRootsByQuery<T>(this IEnumerable<T> source) where T : IQuerySource
     {
-        return source.GroupBy(ds => ds.Query).Select(ds => ds.OrderByDescending(s => s.Level).ThenBy(s => s.Sequence).First());
+        return source.GroupBy(ds => ds.Query).Select(ds => ds.OrderByDescending(s => s.MaxLevel).ThenBy(s => s.Index).First());
     }
 
     /// <summary>

--- a/src/Carbunql/QuerySource.cs
+++ b/src/Carbunql/QuerySource.cs
@@ -6,22 +6,12 @@ namespace Carbunql;
 /// Represents a query source, which can be a physical table, subquery, or common table expression (CTE).
 /// This class implements the IQuerySource interface and provides concrete implementations for its properties.
 /// </summary>
-public class QuerySource(int parentBranch, HashSet<int> indexes, int level, int sequence, HashSet<string> columnNames, SelectQuery query, SelectableTable source) : IQuerySource
+public class QuerySource(int index, HashSet<string> columnNames, SelectQuery query, SelectableTable source) : IQuerySource
 {
-    /// <summary>
-    /// The ID of the parent query source. If it doesn't exist, it's 0.
-    /// </summary>
-    public int ParentIndex { get; } = parentBranch;
-
     /// <summary>
     /// The index of the query source. It is a unique value within a query, starting from 1.
     /// </summary>
-    public int SourceIndex { get; } = indexes.Last();
-
-    /// <summary>
-    /// Indicates the order in which the query source is referenced.
-    /// </summary>
-    public HashSet<int> ReferencedIndexes { get; } = indexes;
+    public int Index { get; } = index;
 
     /// <summary>
     /// Gets the alias name of the query source.
@@ -42,16 +32,13 @@ public class QuerySource(int parentBranch, HashSet<int> indexes, int level, int 
     /// <summary>
     /// The depth level of the query source. Numbering starts from 1 and increments with each nesting level.
     /// </summary>
-    public int Level { get; } = level;
-
-    /// <summary>
-    /// Gets the sequence number within the select query.
-    /// Numbering starts from 1.
-    /// </summary>
-    public int Sequence { get; } = sequence;
+    public int MaxLevel => !References.Any() ? 0 : References.Max(x => x.MaxLevel) + 1;
 
     /// <summary>
     /// The selectable object that contains the query source.
     /// </summary>
     public SelectableTable Source => source;
+
+    public IList<IQuerySource> References { get; } = new List<IQuerySource>();
 }
+

--- a/src/ConsoleApp2/ConsoleApp2.csproj
+++ b/src/ConsoleApp2/ConsoleApp2.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Carbunql\Carbunql.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ConsoleApp2/Program.cs
+++ b/src/ConsoleApp2/Program.cs
@@ -1,0 +1,27 @@
+﻿using Carbunql;
+using Carbunql.Building;
+
+var sql = @"SELECT * FROM sales as s WHERE s.sales_date >= '2023-01-01'";
+
+// 選択クエリをモデル化する
+var query = new SelectQuery(sql);
+
+// salesテーブルを参照しているか検索し、エイリアス名を取得。
+// さらにエイリアス名を使用して検索条件を追加。
+query.GetQuerySources()
+.Where(x => x.GetTableFullName() == "sales")
+.ForEach(x => x.Query.Where($"{x.Alias}.customer_id = 123"));
+
+// 選択クエリに書き戻す
+var modifiedSql = query.ToText();
+Console.WriteLine(modifiedSql);
+
+/*
+SELECT
+    *
+FROM
+    sales AS s
+WHERE
+    s.sales_date >= '2023-01-01'
+    AND s.customer_id = 123
+*/

--- a/test/Carbunql.Building.Test/QueryCommandMonitor.cs
+++ b/test/Carbunql.Building.Test/QueryCommandMonitor.cs
@@ -45,7 +45,7 @@ public class QueryCommandMonitor
         foreach (var ds in srouces)
         {
             Output.WriteLine("--------------------");
-            Output.WriteLine($"Index:{index}, Seq:{ds.Sequence}, Branch:{ds.SourceIndex}, Lv:{ds.Level}");
+            Output.WriteLine($"Index:{index}, Lv:{ds.MaxLevel}");
             Output.WriteLine($"Query:{ds.Query.ToOneLineText()}");
             Output.WriteLine($"Source:{ds.Source.Table.ToOneLineText()}");
             Output.WriteLine($"Table:{ds.GetTableFullName()}");

--- a/test/Carbunql.Building.Test/QuerySourceTest.cs
+++ b/test/Carbunql.Building.Test/QuerySourceTest.cs
@@ -27,7 +27,7 @@ from
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -36,9 +36,8 @@ from
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -62,7 +61,7 @@ where
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -71,9 +70,8 @@ where
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -95,7 +93,7 @@ order by
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -104,9 +102,8 @@ order by
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -129,7 +126,7 @@ group by
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -138,9 +135,8 @@ group by
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -164,7 +160,7 @@ having
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -173,9 +169,8 @@ having
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -202,7 +197,7 @@ where
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -211,9 +206,8 @@ where
         Assert.Single(sources);
 
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -270,7 +264,7 @@ FROM
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -280,9 +274,8 @@ FROM
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -294,9 +287,8 @@ FROM
 
         //index:1
         ds = sources[1];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("d", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -331,7 +323,7 @@ FROM
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Index:{x.Index}, Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -341,9 +333,8 @@ FROM
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -355,9 +346,8 @@ FROM
 
         //index:1
         ds = sources[1];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("d", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -407,7 +397,7 @@ WHERE
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -417,9 +407,8 @@ WHERE
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -430,9 +419,8 @@ WHERE
 
         //index:1
         ds = sources[1];
-        Assert.Equal(2, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -443,9 +431,8 @@ WHERE
 
         //index:2
         ds = sources[2];
-        Assert.Equal(3, ds.Sequence);
-        Assert.Equal(3, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(3, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -483,7 +470,7 @@ FROM
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -493,9 +480,8 @@ FROM
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(3, ds.SourceIndex);
-        Assert.Equal(3, ds.Level);
+        Assert.Equal(3, ds.Index);
+        Assert.Equal(3, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -507,9 +493,8 @@ FROM
 
         //index:1
         ds = sources[1];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("d", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -520,9 +505,8 @@ FROM
 
         //index:2
         ds = sources[2];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("q", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -566,7 +550,7 @@ WHERE
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -576,9 +560,8 @@ WHERE
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(3, ds.SourceIndex);
-        Assert.Equal(3, ds.Level);
+        Assert.Equal(3, ds.Index);
+        Assert.Equal(3, ds.MaxLevel);
         Assert.Equal("s", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -590,9 +573,8 @@ WHERE
 
         //index:1
         ds = sources[1];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("d", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -603,9 +585,8 @@ WHERE
 
         //index:2
         ds = sources[2];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("q", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -616,9 +597,8 @@ WHERE
 
         //index:3
         ds = sources[3];
-        Assert.Equal(2, ds.Sequence);
-        Assert.Equal(4, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(4, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("st", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -668,7 +648,8 @@ ORDER BY
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.ToTreePaths().ForEach(path => x.AddSourceComment($"Path:{string.Join("-", path)}"));
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -678,9 +659,8 @@ ORDER BY
 
         //index:0
         var ds = sources[0];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(2, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(2, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("c", ds.Alias);
 
         var columns = ds.ColumnNames.ToList();
@@ -690,9 +670,8 @@ ORDER BY
 
         //index:1
         ds = sources[1];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(4, ds.SourceIndex);
-        Assert.Equal(3, ds.Level);
+        Assert.Equal(4, ds.Index);
+        Assert.Equal(3, ds.MaxLevel);
         Assert.Equal("sales", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -703,9 +682,8 @@ ORDER BY
 
         //index:2
         ds = sources[2];
-        Assert.Equal(2, ds.Sequence);
-        Assert.Equal(3, ds.SourceIndex);
-        Assert.Equal(2, ds.Level);
+        Assert.Equal(3, ds.Index);
+        Assert.Equal(2, ds.MaxLevel);
         Assert.Equal("ms", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -716,9 +694,8 @@ ORDER BY
 
         //index:3
         ds = sources[3];
-        Assert.Equal(1, ds.Sequence);
-        Assert.Equal(1, ds.SourceIndex);
-        Assert.Equal(1, ds.Level);
+        Assert.Equal(1, ds.Index);
+        Assert.Equal(1, ds.MaxLevel);
         Assert.Equal("r", ds.Alias);
 
         columns = ds.ColumnNames.ToList();
@@ -834,7 +811,8 @@ ORDER BY
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.ToTreePaths().ForEach(path => x.AddSourceComment($"Path:{string.Join("-", path)}"));
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -843,12 +821,12 @@ ORDER BY
         query.GetQuerySources()
         .GetRootsBySource().ForEach(x =>
         {
-            x.AddQueryComment($"Root of Branch:{x.SourceIndex}");
+            x.AddQueryComment($"Root of Branch:{x.Index}");
         });
 
         Monitor.Log(query);
 
-        Assert.Equal(10, sources.Count);
+        Assert.Equal(8, sources.Count);
     }
 
     [Fact]
@@ -898,7 +876,7 @@ ORDER BY
         var query = new SelectQuery(sql);
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Lv:{x.Level}, Seq:{x.Sequence}, Tree:{string.Join("-", x.ReferencedIndexes)}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
         });
         var sources = query.GetQuerySources().ToList();
         Monitor.Log(sources);
@@ -906,11 +884,11 @@ ORDER BY
 
         query.GetQuerySources().ForEach(x =>
         {
-            x.AddSourceComment($"Seq:{x.Sequence}, Branch:{x.SourceIndex}, Lv:{x.Level}");
+            x.AddSourceComment($"Index:{x.Index}, Lv:{x.MaxLevel}");
         })
         .GetRootsBySource().ForEach(x =>
         {
-            x.AddQueryComment($"Root of Branch:{x.SourceIndex}");
+            x.AddQueryComment($"Root of Index:{x.Index}");
         });
 
         Monitor.Log(query);


### PR DESCRIPTION
The issue of the same QuerySource being numbered multiple times has been fixed.
The SourceIndex property has been renamed to the Index property.
The Level property has been renamed to the MaxLevel property.
The Sequence property has been abolished because it was not differentiated from the Index property.