### PR TITLE
Fixed a bug that caused GetRootsBySource to not work.

### DIFF
--- a/demo/CarbunqlWeb/Pages/QuerySource/Labels.razor
+++ b/demo/CarbunqlWeb/Pages/QuerySource/Labels.razor
@@ -55,11 +55,8 @@ var sources = q.GetQuerySources().ToList();
 
 q.GetQuerySources().ForEach(x =>
 {
-x.AddSourceComment($""Lv:{x.Level}, Seq:{x.Sequence}, Refs:{string.Join(""-"", x.ReferencedIndexes)}, Columns:[{string.Join("", "", x.ColumnNames)}]"");
-})
-.GetRootsByBranch().ForEach(x =>
-{
-    x.AddQueryComment($""Root of Branch:{x.Branch}"");
+    x.AddSourceComment($""Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join("", "", x.ColumnNames)}]"");
+    x.ToTreePaths().ForEach(path => x.AddSourceComment($""Path:{string.Join(""-"", path)}""));
 });
 Console.WriteLine(q.ToText());";
 
@@ -88,7 +85,8 @@ Console.WriteLine(q.ToText());";
 
             q.GetQuerySources().ForEach(x =>
             {
-                x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+                x.AddSourceComment($"Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+                x.ToTreePaths().ForEach(path => x.AddSourceComment($"Path:{string.Join("-", path)}"));
             });
 
             fsql = q.ToText();

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.8.4</Version>
+		<Version>0.8.4.1</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/IQuerySource.cs
+++ b/src/Carbunql/IQuerySource.cs
@@ -1,6 +1,5 @@
 ﻿using Carbunql.Clauses;
 using Carbunql.Tables;
-using System.Text;
 
 namespace Carbunql;
 
@@ -41,6 +40,9 @@ public interface IQuerySource
     /// </summary>
     SelectableTable Source { get; }
 
+    /// <summary>
+    /// Gets the query sources that reference this query source.
+    /// </summary>
     IList<IQuerySource> References { get; }
 }
 
@@ -73,6 +75,10 @@ public static class IQuerySourceExtension
     {
         var result = new List<List<int>>();
         BuildTreePaths(source, new List<int>(), result);
+
+        //set root querysource(index:0)
+        result.ForEach(x => x.Add(0));
+
         return result;
     }
 

--- a/src/Carbunql/QuerySource.cs
+++ b/src/Carbunql/QuerySource.cs
@@ -32,7 +32,7 @@ public class QuerySource(int index, HashSet<string> columnNames, SelectQuery que
     /// <summary>
     /// The depth level of the query source. Numbering starts from 1 and increments with each nesting level.
     /// </summary>
-    public int MaxLevel => !References.Any() ? 0 : References.Max(x => x.MaxLevel) + 1;
+    public int MaxLevel => !References.Any() ? 1 : References.Max(x => x.MaxLevel) + 1;
 
     /// <summary>
     /// The selectable object that contains the query source.


### PR DESCRIPTION
Fixed an issue where the GetRootsBySource function would return a QuerySource other than Root.

A dummy query source was added to the zeroth element of the References property, but this has been discontinued. Instead, when using the ToTreePaths function, the end point is always the zeroth.