### PR TITLE
Improved analysis of union queries

### DIFF
--- a/src/Carbunql/Analysis/ReadQueryParser.cs
+++ b/src/Carbunql/Analysis/ReadQueryParser.cs
@@ -30,4 +30,30 @@ public static class ReadQueryParser
 
         throw new NotSupportedException($"Unsupported token: '{r.Peek()}'");
     }
+
+    /// <summary>
+    /// Parses the READ query while ignoring surrounding brackets.
+    /// </summary>
+    /// <param name="r">The ITokenReader instance.</param>
+    /// <returns>The parsed ReadQuery object.</returns>
+    internal static ReadQuery ParseIgnoringBrackets(ITokenReader r)
+    {
+        // Skip opening brackets
+        var cnt = 0;
+        while (r.TryRead("(", out _))
+        {
+            cnt++;
+        }
+
+        var q = Parse(r);
+
+        // Skip closing brackets
+        while (cnt > 0)
+        {
+            r.Read(")");
+            cnt--;
+        }
+
+        return q;
+    }
 }

--- a/src/Carbunql/Analysis/SelectQueryParser.cs
+++ b/src/Carbunql/Analysis/SelectQueryParser.cs
@@ -48,8 +48,9 @@ public static class SelectQueryParser
         var tokens = new string[] { "union", "union all", "except", "minus", "intersect" };
         while (r.Peek().IsEqualNoCase(tokens))
         {
+            //read operator
             var op = r.Read();
-            sq.AddOperatableValue(op, ParseMain(r));
+            sq.AddOperatableValue(op, ReadQueryParser.ParseIgnoringBrackets(r));
         }
 
         sq.LimitClause = ParseLimitOrDefault(r);
@@ -65,7 +66,6 @@ public static class SelectQueryParser
     private static SelectQuery ParseMain(ITokenReader r)
     {
         var sq = new SelectQuery();
-
         r.Read("select");
 
         sq.SelectClause = SelectClauseParser.Parse(r);

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.8.7</Version>
+		<Version>0.8.8</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/IReadQuery.cs
+++ b/src/Carbunql/IReadQuery.cs
@@ -12,29 +12,36 @@ namespace Carbunql;
 public interface IReadQuery : IQueryCommandable
 {
     /// <summary>
-    /// Gets the select clause of the read query.
+    /// Gets the SELECT clause of the read query.
     /// </summary>
-    /// <returns>The select clause if present, otherwise null.</returns>
+    /// <returns>The SELECT clause if present; otherwise, null.</returns>
     SelectClause? GetSelectClause();
 
     /// <summary>
-    /// Gets the with clause of the read query.
+    /// Gets the WITH clause of the read query.
     /// </summary>
-    /// <returns>The with clause if present, otherwise null.</returns>
+    /// <returns>The WITH clause if present; otherwise, null.</returns>
     WithClause? GetWithClause();
 
     /// <summary>
     /// Gets or creates a new <see cref="SelectQuery"/> associated with this read query.
     /// </summary>
-    /// <returns>The <see cref="SelectQuery"/>.</returns>
+    /// <returns>A <see cref="SelectQuery"/> instance.</returns>
     SelectQuery GetOrNewSelectQuery();
 
     /// <summary>
-    /// Gets the column names involved in the read query.
+    /// Gets the names of the columns involved in the read query.
     /// </summary>
-    /// <returns>An enumerable of column names.</returns>
+    /// <returns>An enumerable collection of column names.</returns>
     IEnumerable<string> GetColumnNames();
+
+    /// <summary>
+    /// Gets the operatable queries associated with this read query.
+    /// </summary>
+    /// <returns>An enumerable collection of <see cref="OperatableQuery"/> instances.</returns>
+    IEnumerable<OperatableQuery> GetOperatableQueries();
 }
+
 
 /// <summary>
 /// Extension methods for <see cref="IReadQuery"/>.

--- a/src/Carbunql/Tables/VirtualTable.cs
+++ b/src/Carbunql/Tables/VirtualTable.cs
@@ -76,12 +76,22 @@ public class VirtualTable : TableBase
     }
 
     /// <inheritdoc/>
-    public override bool IsSelectQuery => _isSelectQuery;
+    public override bool IsSelectQuery => IsSelectQueryCore();
+
+    internal bool IsSelectQueryCore()
+    {
+        if (_isSelectQuery) return true;
+        if (Query is VirtualTable vt) return vt.IsSelectQueryCore();
+
+        return false;
+    }
 
     /// <inheritdoc/>
     public override SelectQuery GetSelectQuery()
     {
         if (_isSelectQuery) return (SelectQuery)Query;
+        if (Query is VirtualTable vt) return vt.GetSelectQuery();
+
         return base.GetSelectQuery();
     }
 


### PR DESCRIPTION
Selection queries enclosed in excessive parentheses can now be analyzed. 
The excessive parentheses will be removed.
Fixed a bug where indentation was not reflected correctly when combining union queries.