### PR TITLE
Improved Fluent filtering function

### DIFF
--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -7,13 +7,13 @@
 		<Nullable>enable</Nullable>
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
-		<Description>Carbunql provides query parsing and building functionality.</Description>
-		<Version>0.8.9</Version>
+		<Description>Carbunql is an advanced dynamic SQL building library.</Description>
+		<Version>0.8.9.1</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<RepositoryUrl>https://github.com/mk3008/Carbunql.git</RepositoryUrl>
-		<PackageTags>sql;migration;sql-parser;query-builder;sql-builder;sqlbuilder;sqlparser;sqlrebuilder</PackageTags>
+		<PackageTags>sql;migration;sql-parser;query-builder;sql-builder;sqlbuilder;sqlparser;dynamic programming</PackageTags>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>
 
@@ -35,7 +35,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="MessagePack" Version="2.5.124" />
 		<PackageReference Include="MessagePackAnalyzer" Version="2.5.124">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Carbunql/IEnumerableExtension.cs
+++ b/src/Carbunql/IEnumerableExtension.cs
@@ -4,77 +4,83 @@ namespace Carbunql;
 
 public static class IEnumerableExtension
 {
-    public static IEnumerable<T> ForEach<T>(this IEnumerable<T> items, Action<T> action)
-    {
-        foreach (var item in items)
-        {
-            action(item);
-        }
-        return items;
-    }
+	public static IEnumerable<T> ForEach<T>(this IEnumerable<T> items, Action<T> action)
+	{
+		foreach (var item in items)
+		{
+			action(item);
+		}
+		return items;
+	}
 
-    /// <summary>
-    /// Gets the root query sources which are not referenced by any other query sources.
-    /// </summary>
-    public static IEnumerable<IQuerySource> GetRootsBySource(this IEnumerable<IQuerySource> querySources)
-    {
-        var querySourceList = querySources.OrderByDescending(x => x.MaxLevel).ToList();
+	/// <summary>
+	/// Gets the root query sources which are not referenced by any other query sources.
+	/// </summary>
+	public static IEnumerable<IQuerySource> GetRootsBySource(this IEnumerable<IQuerySource> querySources)
+	{
+		var querySourceList = querySources.OrderByDescending(x => x.MaxLevel).ToList();
 
-        var rootQuerySources = new List<IQuerySource>();
-        var roots = new List<List<int>>();
+		var rootQuerySources = new List<IQuerySource>();
+		var roots = new List<List<int>>();
 
-        foreach (var qs in querySourceList)
-        {
-            var paths = qs.ToTreePaths();
-            var isRoot = true;
+		foreach (var qs in querySourceList)
+		{
+			var paths = qs.ToTreePaths();
+			var isRoot = true;
 
-            foreach (var root in roots)
-            {
-                foreach (var path in paths)
-                {
-                    if (root.Contains(path.First()))
-                    {
-                        isRoot = false;
-                    }
-                }
-            }
-            if (isRoot)
-            {
-                rootQuerySources.Add(qs);
-                foreach (var path in paths)
-                {
-                    roots.Add(path);
-                }
-            }
-        }
+			foreach (var root in roots)
+			{
+				foreach (var path in paths)
+				{
+					if (root.Contains(path.First()))
+					{
+						isRoot = false;
+					}
+				}
+			}
+			if (isRoot)
+			{
+				rootQuerySources.Add(qs);
+				foreach (var path in paths)
+				{
+					roots.Add(path);
+				}
+			}
+		}
 
-        return rootQuerySources;
-    }
+		return rootQuerySources;
+	}
 
-    /// <summary>
-    /// Retrieves one QuerySource per query. The retrieval order is descending by Level and ascending by Sequence.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="source">The source collection of QuerySources.</param>
-    /// <returns>A collection of QuerySources, one per query, ordered by descending Level and ascending Sequence.</returns>
-    public static IEnumerable<T> GetRootsByQuery<T>(this IEnumerable<T> source) where T : IQuerySource
-    {
-        return source.GroupBy(ds => ds.Query).Select(ds => ds.OrderByDescending(s => s.MaxLevel).ThenBy(s => s.Index).First());
-    }
+	/// <summary>
+	/// Retrieves one QuerySource per query. The retrieval order is descending by Level and ascending by Sequence.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="source">The source collection of QuerySources.</param>
+	/// <returns>A collection of QuerySources, one per query, ordered by descending Level and ascending Sequence.</returns>
+	public static IEnumerable<T> GetRootsByQuery<T>(this IEnumerable<T> source) where T : IQuerySource
+	{
+		return source.GroupBy(ds => ds.Query).Select(ds => ds.OrderByDescending(s => s.MaxLevel).ThenBy(s => s.Index).First());
+	}
 
-    /// <summary>
-    /// Ensures that the enumerable source contains at least one element.
-    /// Throws an <see cref="InvalidOperationException"/> if no elements are found.
-    /// </summary>
-    /// <typeparam name="T">The type of elements in the enumerable, must implement <see cref="IQuerySource"/>.</typeparam>
-    /// <param name="source">The enumerable source to check.</param>
-    /// <returns>The same enumerable source if it contains any elements.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when no elements are found in the enumerable source.</exception>
-    public static IEnumerable<T> EnsureAny<T>(this IEnumerable<T> source) where T : IQuerySource
-    {
-        if (source.Any())
-            return source;
+	/// <summary>
+	/// Ensures that the enumerable source contains at least one element.
+	/// Throws an <see cref="InvalidOperationException"/> if no elements are found.
+	/// </summary>
+	/// <typeparam name="T">The type of elements in the enumerable, must implement <see cref="IQuerySource"/>.</typeparam>
+	/// <param name="source">The enumerable source to check.</param>
+	/// <returns>The same enumerable source if it contains any elements.</returns>
+	/// <exception cref="InvalidOperationException">Thrown when no elements are found in the enumerable source.</exception>
+	public static IEnumerable<T> EnsureAny<T>(this IEnumerable<T> source, string appendErroressage = "") where T : IQuerySource
+	{
+		if (source.Any()) return source;
 
-        throw new InvalidOperationException("No matching QuerySource was found.");
-    }
+		if (string.IsNullOrEmpty(appendErroressage))
+		{
+			throw new InvalidOperationException($"No matching QuerySource was found.");
+		}
+		else
+		{
+			throw new InvalidOperationException($"No matching QuerySource was found. {appendErroressage}");
+		}
+	}
 }

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -21,1269 +21,1269 @@ namespace Carbunql;
 [MessagePackObject(keyAsPropertyName: true)]
 public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 {
-	/// <summary>
-	/// Initializes a new instance of the <see cref="SelectQuery"/> class.
-	/// </summary>
-	/// <remarks>
-	/// This constructor initializes a new instance of the SelectQuery class in an empty state.
-	/// After instantiation, additional processing is required to populate components such as the SELECT clause and FROM clause.
-	/// </remarks>
-	public SelectQuery() { }
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="SelectQuery"/> class from the provided SQL query string.
-	/// </summary>
-	/// <param name="query">The SQL select query string.</param>
-	/// <remarks>
-	/// This constructor parses the provided SQL query string and initializes the select query object with its components, such as SELECT, FROM, WHERE, GROUP BY, HAVING, and ORDER BY clauses.
-	/// The query string may contain additional clauses such as WITH, WINDOW, and LIMIT, which are also parsed and initialized if present.
-	/// </remarks>
-	public SelectQuery(string query)
-	{
-		var parsedQuery = SelectQueryParser.Parse(query);
-		WithClause = parsedQuery.WithClause;
-		SelectClause = parsedQuery.SelectClause;
-		FromClause = parsedQuery.FromClause;
-		WhereClause = parsedQuery.WhereClause;
-		GroupClause = parsedQuery.GroupClause;
-		HavingClause = parsedQuery.HavingClause;
-		WindowClause = parsedQuery.WindowClause;
-		OperatableQueries = parsedQuery.OperatableQueries;
-		OrderClause = parsedQuery.OrderClause;
-		LimitClause = parsedQuery.LimitClause;
-	}
-
-	/// <summary>
-	/// Gets or sets the WITH clause of the select query.
-	/// Common Table Expressions (CTE) are available.
-	/// </summary>
-	public WithClause? WithClause { get; set; } = new();
-
-	/// <summary>
-	/// Gets or sets the SELECT clause of the select query.
-	/// The SELECT clause specifies which columns to retrieve from the database.
-	/// </summary>
-	public SelectClause? SelectClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the FROM clause of the select query.
-	/// The FROM clause specifies the table, view, CTE (Common Table Expression), or subquery from which to retrieve data.
-	/// </summary>
-	public FromClause? FromClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the WHERE clause of the select query.
-	/// The WHERE clause specifies the conditions that must be met for a row to be returned by the query.
-	/// </summary>
-	public WhereClause? WhereClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the GROUP BY clause of the select query.
-	/// The GROUP BY clause is used to group rows that have the same values into summary rows.
-	/// </summary>
-	public GroupClause? GroupClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the HAVING clause of the select query.
-	/// The HAVING clause is used to filter groups that appear in the result set, typically used in conjunction with the GROUP BY clause.
-	/// </summary>
-	public HavingClause? HavingClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the WINDOW clause of the select query.
-	/// The WINDOW clause defines a window or set of rows for a query result.
-	/// </summary>
-	public WindowClause? WindowClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the comment clause of the select clause.
-	/// </summary>
-	/// <remarks>
-	/// A comment that is output before the selection clause. It is suitable for indicating the nature of the selection query.
-	/// Since it is output after the With clause, it is less visible than the HeaderCommentClause.
-	/// </remarks>
-	[IgnoreMember]
-	public CommentClause? CommentClause { get; set; }
-
-	/// <summary>
-	/// Gets or sets the comment clause for the select query.
-	/// This is printed before the With clause, which can be useful for debugging.
-	/// </summary>
-	/// <remarks>
-	/// This is printed before the With clause and is useful for debugging.
-	/// However, it is not printed if it is not the root query.
-	/// </remarks>
-	[IgnoreMember]
-	public CommentClause? HeaderCommentClause { get; set; }
-
-	public void AddHeaderComment(string comment)
-	{
-		HeaderCommentClause ??= new CommentClause();
-		HeaderCommentClause.Add(comment);
-	}
-
-	public IList<IQuerySource> GetQuerySources()
-	{
-		var commonTables = GetCommonTables().ToList();
-		var sources = new List<IQuerySource>();
-		var lst = CreateQuerySources(ref sources, commonTables, new Numbering(0));
-
-		return sources;
-	}
-
-	private IList<IQuerySource> CreateQuerySources(ref List<IQuerySource> sources, IList<CommonTable> commonTables, Numbering numbering)
-	{
-		if (FromClause == null) return new List<IQuerySource>();
-
-		var currentSources = new List<IQuerySource>();
-
-		var hasRelation = (FromClause.Relations?.Any() ?? false);
-		var columns = GetColumns().ToList();
-
-		if (hasRelation && columns.Any(x => string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-		{
-			var cols = string.Join(", ", columns.Where(x => string.IsNullOrEmpty(x.TableAlias)).Select(x => x.Column).Distinct());
-			throw new InvalidProgramException($"There are columns whose table alias names cannot be parsed: {cols}.");
-		}
-
-		foreach (var source in GetQuerySourceSelectableTables())
-		{
-			if (sources.Where(x => x.Source == source).Any())
-			{
-				var qs = sources.Where(x => x.Source == source).First();
-				currentSources.Add(qs);
-			}
-			else if (source.Table.TryGetSelectQuery(out var query))
-			{
-				var qs = DisassembleQuerySources(ref sources, source, query, commonTables, numbering, SourceType.SubQuery);
-				currentSources.Add(qs);
-			}
-			else if (source.Table is PhysicalTable table && commonTables.Any(x => x.Alias == table.GetTableFullName()))
-			{
-				// disassemble cte
-				var ct = commonTables.First(x => x.Alias == table.GetTableFullName());
-
-				if (ct.IsSelectQuery)
-				{
-					// select query
-
-					// Only those declared before this will be recognized as CTEs
-					var id = commonTables.IndexOf(ct);
-					var ctes = commonTables.Where((item, index) => index < id).ToList();
-
-					var commonQuery = commonTables.First(x => x.Alias == table.GetTableFullName()).GetSelectQuery();
-					var qs = DisassembleQuerySources(ref sources, source, commonQuery, ctes, numbering, SourceType.CommonTableExtension);
-					currentSources.Add(qs);
-				}
-				else if (ct.Table is VirtualTable vt && vt.Query is ValuesQuery && ct.ColumnAliases != null)
-				{
-					// values query
-					var names = ct.ColumnAliases.OfType<ColumnValue>().Select(x => x.Column).ToHashSet();
-
-					var qs = new QuerySource(numbering.GetNext(), names, this, source, SourceType.ValuesQuery);
-					sources.Add(qs);
-					currentSources.Add(qs);
-				}
-				else
-				{
-					throw new NotSupportedException();
-				}
-			}
-			else
-			{
-				var cname = columns
-					.Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-					.Select(x => x.Column)
-					.ToHashSet();
-
-				var qs = new QuerySource(numbering.GetNext(), cname, this, source, SourceType.PhysicalTable);
-				sources.Add(qs);
-				currentSources.Add(qs);
-			}
-		}
-
-		// ex. union query
-		foreach (var item in OperatableQueries.Select(x => x.Query).OfType<SelectQuery>())
-		{
-			foreach (var qs in item.CreateQuerySources(ref sources, commonTables, numbering))
-			{
-				currentSources.Add(qs);
-			}
-		}
-
-		return currentSources;
-	}
-
-	private IQuerySource DisassembleQuerySources(ref List<IQuerySource> sources, SelectableTable source, SelectQuery query, IList<CommonTable> commonTables, Numbering numbering, SourceType type)
-	{
-		var index = numbering.GetNext();
-
-		var parents = query.CreateQuerySources(ref sources, commonTables, numbering);
-
-		var cname = query.GetColumnNames().ToList();
-
-		// decode wild card
-		if (cname.Contains("*"))
-		{
-			var allColumns = new Dictionary<string, IEnumerable<string>>();
-			foreach (var nestedSource in parents)
-			{
-				allColumns[nestedSource.Alias] = nestedSource.ColumnNames;
-			}
-
-			cname.Remove("*");
-
-			var wilds = query.SelectClause!.Where(x => x.Alias == "*");
-			foreach (var wild in wilds.Select(x => x.Value).OfType<ColumnValue>())
-			{
-				if (string.IsNullOrEmpty(wild.TableAlias))
-				{
-					// all
-					cname.AddRange(allColumns.SelectMany(x => x.Value));
-					break;
-				}
-				else
-				{
-					//table all
-					cname.AddRange(allColumns[wild.TableAlias]);
-				}
-			}
-		}
-
-		// If not available, infer the column names from your query
-		if (!cname.Any() && FromClause != null)
-		{
-			var hasRelation = (FromClause.Relations?.Any() ?? false);
-			var columns = GetColumns().ToList();
-
-			cname = columns
-				.Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-				.Select(x => x.Column)
-				.ToList();
-		}
-
-		var qs = new QuerySource(index, cname.ToHashSet(), this, source, type);
-
-		foreach (var item in parents)
-		{
-			item.References.Add(qs);
-		}
-		sources.Add(qs);
-
-		return qs;
-	}
-
-	private IEnumerable<SelectableTable> GetQuerySourceSelectableTables()
-	{
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetSelectableTables())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetSelectableTables())
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
-	{
-		// If this is a root query, a header comment is printed on the first line.
-		if (parent == null && HeaderCommentClause != null)
-		{
-			foreach (var item in HeaderCommentClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (parent == null && WithClause != null)
-		{
-			var commonTables = GetCommonTables();
-			foreach (var item in WithClause.GetTokens(parent, commonTables))
-			{
-				yield return item;
-			}
-		}
-
-		// Comments will be unified to be displayed just before the selected section.
-		if (CommentClause != null)
-		{
-			foreach (var item in CommentClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (SelectClause == null)
-		{
-			// If SelectClause is not specified,
-			// all columns are assumed to be selected.
-			var clause = Token.Reserved(this, parent, "select");
-			yield return clause;
-			yield return new Token(this, clause, "*");
-		}
-		else
-		{
-			foreach (var item in SelectClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (FromClause == null) yield break;
-
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetTokens(parent))
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public override WithClause? GetWithClause() => WithClause;
-
-	/// <inheritdoc/>
-	public override SelectClause? GetSelectClause() => SelectClause;
-
-	/// <inheritdoc/>
-	public override SelectQuery GetOrNewSelectQuery() => this;
-
-	/// <inheritdoc/>
-	public override IEnumerable<QueryParameter> GetInnerParameters()
-	{
-		var fromClauseParameters = FromClause?.GetParameters();
-		if (fromClauseParameters != null)
-		{
-			foreach (var item in fromClauseParameters)
-			{
-				yield return item;
-			}
-		}
-
-		var whereClauseParameters = WhereClause?.GetParameters();
-		if (whereClauseParameters != null)
-		{
-			foreach (var item in whereClauseParameters)
-			{
-				yield return item;
-			}
-		}
-
-		var groupClauseParameters = GroupClause?.GetParameters();
-		if (groupClauseParameters != null)
-		{
-			foreach (var item in groupClauseParameters)
-			{
-				yield return item;
-			}
-		}
-
-		var havingClauseParameters = HavingClause?.GetParameters();
-		if (havingClauseParameters != null)
-		{
-			foreach (var item in havingClauseParameters)
-			{
-				yield return item;
-			}
-		}
-
-		var windowClauseParameters = WindowClause?.GetParameters();
-		if (windowClauseParameters != null)
-		{
-			foreach (var item in windowClauseParameters)
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
-	{
-		var vt = new VirtualTable(this);
-		if (columnAliases != null)
-		{
-			return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
-		}
-		return new SelectableTable(vt, "q");
-	}
-
-	/// <inheritdoc/>
-	public override IEnumerable<string> GetColumnNames()
-	{
-		if (SelectClause == null) return Enumerable.Empty<string>();
-		return SelectClause.Select(x => x.Alias);
-	}
-
-	/// <inheritdoc/>
-	public override IEnumerable<PhysicalTable> GetPhysicalTables()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetPhysicalTables())
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public override IEnumerable<SelectQuery> GetInternalQueries()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-
-		yield return this;
-
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetInternalQueries())
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public IEnumerable<SelectableItem> GetSelectableItems()
-	{
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause)
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <inheritdoc/>
-	public IEnumerable<SelectableTable> GetSelectableTables()
-	{
-		if (FromClause == null) yield break;
-		foreach (var item in FromClause.GetSelectableTables()) yield return item;
-	}
-
-	/// <inheritdoc/>
-	public override IEnumerable<CommonTable> GetCommonTables()
-	{
-		if (WithClause != null)
-		{
-			foreach (var item in WithClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		foreach (var oq in OperatableQueries)
-		{
-			foreach (var item in oq.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetCommonTables())
-			{
-				yield return item;
-			}
-		}
-	}
-
-	public override IEnumerable<ColumnValue> GetColumns()
-	{
-		if (SelectClause != null)
-		{
-			foreach (var item in SelectClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (FromClause != null)
-		{
-			foreach (var item in FromClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (WhereClause != null)
-		{
-			foreach (var item in WhereClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (GroupClause != null)
-		{
-			foreach (var item in GroupClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (HavingClause != null)
-		{
-			foreach (var item in HavingClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (WindowClause != null)
-		{
-			foreach (var item in WindowClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (OrderClause != null)
-		{
-			foreach (var item in OrderClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-		if (LimitClause != null)
-		{
-			foreach (var item in LimitClause.GetColumns())
-			{
-				yield return item;
-			}
-		}
-	}
-
-	/// <summary>
-	/// This method tries to convert the SelectQuery instance to a ValuesQuery instance.
-	/// </summary>
-	/// <param name="query">The resulting ValuesQuery if conversion succeeds; otherwise, default.</param>
-	/// <returns>True if the conversion succeeds; otherwise, false.</returns>
-	public bool TryToValuesQuery([MaybeNullWhen(false)] out ValuesQuery query)
-	{
-		query = default;
-		if (SelectClause is null) return false;
-
-		var row = new ValueCollection(SelectClause.Select(x => x.Value).ToList<ValueBase>());
-		var q = new ValuesQuery();
-		q.Rows.Add(row);
-
-		foreach (var item in OperatableQueries)
-		{
-			if (item.Query is SelectQuery sq)
-			{
-				if (sq.TryToValuesQuery(out var vq))
-				{
-					q.Rows.AddRange(vq.Rows);
-				}
-				else
-				{
-					return false;
-				}
-			}
-			else if (item.Query is ValuesQuery vq)
-			{
-				q.Rows.AddRange(vq.Rows);
-			}
-		}
-
-		// Conversion is not possible if the number of columns is different.
-		if (q.Rows.Min(x => x.Count()) != q.Rows.Max(x => x.Count()))
-		{
-			return false;
-		}
-
-		query = q;
-		return true;
-	}
-
-	private class Numbering(int startIndex)
-	{
-		public int Current { get; private set; } = startIndex;
-		public int GetNext()
-		{
-			Current++;
-			return Current;
-		}
-	}
-
-	/// <summary>
-	/// Returns a select query that references itself as a CTE (Common Table Expression).
-	/// </summary>
-	/// <param name="name">The name of the CTE.</param>
-	/// <param name="alias">
-	/// The alias to use. If omitted, the select clause will use a wildcard.
-	/// </param>
-	/// <returns>The modified select query with the CTE reference.</returns>
-	/// <exception cref="InvalidProgramException">
-	/// Thrown if a CTE with the same name already exists.
-	/// </exception>
-	public SelectQuery ToCTEQuery(string name, string alias = "")
-	{
-		if (GetCommonTables().Where(x => x.Alias.IsEqualNoCase(name)).Any())
-		{
-			throw new InvalidProgramException($"A CTE with the same name already exists. Name: {name}");
-		}
-
-		var (q, t) = this.ToCTE(name);
-
-		if (string.IsNullOrEmpty(alias))
-		{
-			q.From(t).As(name);
-			q.SelectAll();
-		}
-		else
-		{
-			q.From(t).As(alias);
-			GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
-		}
-
-		return q;
-	}
-
-	/// <summary>
-	/// Returns a select query that references itself as a subquery.
-	/// </summary>
-	/// <param name="alias">The alias to use for the subquery.</param>
-	/// <returns>The modified select query with the subquery reference.</returns>
-	public SelectQuery ToSubQuery(string alias)
-	{
-		var q = new SelectQuery();
-		var (f, t) = q.From(this).As(alias);
-
-		GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
-
-		return q;
-	}
-
-	[Obsolete("use AddCteQuery method")]
-	public SelectQuery AddCTEQuery(string query, string alias)
-	{
-		return AddCteQuery(query, alias);
-	}
-
-	public SelectQuery AddCteQuery(string query, string alias)
-	{
-		this.With(query).As(alias);
-		return this;
-	}
-
-	public SelectQuery AddFrom(string table, string alias)
-	{
-		if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
-		FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
-		return this;
-	}
-
-	public SelectQuery AddFrom(string table, string alias, IEnumerable<string> selectColumns)
-	{
-		if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
-		FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
-		selectColumns.ForEach(x => this.Select(new ColumnValue(alias, x)));
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a column to the select clause.
-	/// </summary>
-	/// <param name="column">The column information.</param>
-	/// <param name="alias">The alias name for the column.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddSelect(string column, string alias)
-	{
-		this.Select(column).As(alias);
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a column to the select clause.
-	/// </summary>
-	/// <param name="column">The column information.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddSelect(string column)
-	{
-		var val = ValueParser.Parse(column);
-		if (val is ColumnValue c)
-		{
-			this.Select(c).As(c.GetDefaultName());
-			return this;
-		}
-		throw new InvalidOperationException();
-	}
-
-	public SelectQuery AddSelectAll(string tableName)
-	{
-		var t = GetSelectableTables().Where(x => x.Table.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName)).FirstOrDefault();
-		if (t == null)
-		{
-			throw new InvalidProgramException($"Table not found. table:{tableName}");
-		}
-
-		GetQuerySources()
-			.Where(x => x.Source.Equals(t))
-			.GetRootsBySource()
-			.EnsureAny()
-			.ForEach(x =>
-			{
-				x.ColumnNames.ForEach(column => this.Select(x.Alias, column));
-			});
-		return this;
-	}
-
-	public SelectQuery RenameSelect(string columnAliasName, string newAliasName)
-	{
-		var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
-		c.SetAlias(newAliasName);
-		return this;
-	}
-
-	public SelectQuery RemoveSelect(string selectableColumnName)
-	{
-		var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(selectableColumnName)).First();
-		SelectClause!.Remove(c);
-		return this;
-	}
-
-	public SelectQuery RemoveSelectAll()
-	{
-		SelectClause = null;
-		return this;
-	}
-
-	/// <summary>
-	/// Searches for the specified column and overrides it.
-	/// </summary>
-	/// <param name="columnAliasName">The name of the column to search for.</param>
-	/// <param name="overrider">The function to modify the column value.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery OverrideSelect(string columnAliasName, Func<IQuerySource, string, string> overrider)
-	{
-		GetQuerySources()
-			.Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
-			.EnsureAny($"column alias:{columnAliasName}")
-			.GetRootsBySource()
-			.ForEach(x =>
-			{
-				var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
-				//override
-				si.Value = ValueParser.Parse(overrider(x, si.Value.ToOneLineText()));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Searches for the specified column in the specified table and overrides it.
-	/// </summary>
-	/// <param name="tableName">The name of the table to search in.</param>
-	/// <param name="columnAliasName">The name of the column to search for.</param>
-	/// <param name="overrider">The function to modify the column value.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery OverrideSelect(string tableName, string columnAliasName, Func<IQuerySource, SelectableItem, string> overrider)
-	{
-		GetQuerySources()
-			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
-			.EnsureAny($"table:{tableName}")
-			.Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
-			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column alias:{columnAliasName}")
-			.GetRootsBySource()
-			.EnsureAny()
-			.ForEach(x =>
-			{
-				var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
-				//override
-				si.Value = ValueParser.Parse(overrider(x, si));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="columnName">The name of the column to search in.</param>
-	/// <param name="adder">The function to create the search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(string columnName, Func<IQuerySource, string> adder)
-	{
-		GetQuerySources()
-			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
-			.EnsureAny($"column:{columnName}")
-			.GetRootsBySource()
-			.ForEach(x =>
-			{
-				x.Query.Where(adder(x));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="columnName">The name of the column to search in.</param>
-	/// <param name="adder">The function to create the search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(string columnName, Func<IQuerySource, string, string> adder)
-	{
-		GetQuerySources()
-			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
-			.EnsureAny($"column:{columnName}")
-			.GetRootsBySource()
-			.ForEach(x =>
-			{
-				x.Query.Where(adder(x, columnName));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="condition">search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(string condition)
-	{
-		this.Where(condition);
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="adder">The function to create the search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(Func<string> adder)
-	{
-		this.Where(adder());
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="tableName">The name of the table to search in.</param>
-	/// <param name="columnName">The name of the column to search in.</param>
-	/// <param name="adder">The function to create the search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string> adder)
-	{
-		GetQuerySources()
-			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
-			.EnsureAny($"table:{tableName}")
-			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
-			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
-			.GetRootsBySource()
-			.ForEach(x =>
-			{
-				x.Query.Where(adder(x));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a search condition.
-	/// </summary>
-	/// <param name="tableName">The name of the table to search in.</param>
-	/// <param name="columnName">The name of the column to search in.</param>
-	/// <param name="adder">The function to create the search condition.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string, string> adder)
-	{
-		GetQuerySources()
-			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
-			.EnsureAny($"table:{tableName}")
-			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
-			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
-			.GetRootsBySource()
-			.ForEach(x =>
-			{
-				x.Query.Where(adder(x, columnName));
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds an EXISTS clause.
-	/// </summary>
-	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
-	/// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
-	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-	{
-		GetQuerySources()
-			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-			.EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
-			.GetRootsBySource()
-			.ForEach(qs =>
-			{
-				qs.Query.Where(() =>
-				{
-					var sq = new SelectQuery($"select * from {validationTableName} as x");
-					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-					return sq.ToExists();
-				});
-				action?.Invoke(qs);
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds an EXISTS clause.
-	/// </summary>
-	/// <param name="sourceTableName">The name of the table to search in.</param>
-	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
-	/// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
-	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-	{
-		GetQuerySources()
-			.Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName) || x.Alias.IsEqualNoCase(sourceTableName))
-			.EnsureAny($"table:{sourceTableName}")
-			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
-			.GetRootsBySource()
-			.EnsureAny()
-			.ForEach(qs =>
-			{
-				qs.Query.Where(() =>
-				{
-					var sq = new SelectQuery($"select * from {validationTableName} as x");
-					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-					return sq.ToExists();
-				});
-				action?.Invoke(qs);
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a NOT EXISTS clause.
-	/// </summary>
-	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
-	/// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
-	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddNotExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-	{
-		GetQuerySources()
-			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-			.EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
-			.GetRootsBySource()
-			.ForEach(qs =>
-			{
-				qs.Query.Where(() =>
-				{
-					var sq = new SelectQuery($"select * from {validationTableName} as x");
-					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-					return sq.ToNotExists();
-				});
-				action?.Invoke(qs);
-			});
-
-		return this;
-	}
-
-	/// <summary>
-	/// Adds a NOT EXISTS clause.
-	/// </summary>
-	/// <param name="sourceTableName">The name of the table to search in.</param>
-	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
-	/// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
-	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-	/// <returns>The modified select query.</returns>
-	public SelectQuery AddNotExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-	{
-		GetQuerySources()
-			.Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName))
-			.EnsureAny($"table:{sourceTableName}")
-			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
-			.GetRootsBySource()
-			.ForEach(qs =>
-			{
-				qs.Query.Where(() =>
-				{
-					var sq = new SelectQuery($"select * from {validationTableName} as x");
-					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-					return sq.ToNotExists();
-				});
-				action?.Invoke(qs);
-			});
-
-		return this;
-	}
-
-	public SelectQuery AddJoin(string joinType, string table, string alias, string condition)
-	{
-		var f = FromClause!;
-		var t = TableParser.Parse(table);
-		var r = f.Join(t.ToSelectable(alias), joinType);
-		r.On(condition);
-		return this;
-	}
-
-	public SelectQuery AddJoin(string joinType, string table, string alias, Func<string> builder)
-	{
-		var f = FromClause!;
-		var t = TableParser.Parse(table);
-		var r = f.Join(t.ToSelectable(alias), joinType);
-		r.On(builder);
-		return this;
-	}
-
-	public SelectQuery AddSelectQuery(string jointType, Func<SelectQuery, SelectQuery> builder)
-	{
-		AddOperatableValue(jointType, builder(this));
-		return this;
-	}
-
-	public SelectQuery ImportCTEQueries(SelectQuery from)
-	{
-		from.GetCommonTables().ForEach(x => this.With(x));
-		return this;
-	}
-
-	public SelectQuery AddParameter(QueryParameter prm)
-	{
-		Parameters.Add(prm);
-		return this;
-	}
-
-	public SelectQuery AddOrder(string columnName, Func<IQuerySource, string, string> adder)
-	{
-		GetQuerySources()
-			.Where(x => x.Query.Equals(this))
-			.ForEach(x =>
-			{
-				x.Query.OrderClause ??= new();
-				x.Query.OrderClause.Add(SortableItemParser.Parse(adder(x, columnName)));
-			});
-
-		return this;
-	}
-
-	public SelectQuery FilterInColumns(IEnumerable<string> columnNames)
-	{
-		if (SelectClause == null) throw new NullReferenceException(nameof(SelectClause));
-		SelectClause.FilterInColumns(columnNames);
-		return this;
-	}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SelectQuery"/> class.
+    /// </summary>
+    /// <remarks>
+    /// This constructor initializes a new instance of the SelectQuery class in an empty state.
+    /// After instantiation, additional processing is required to populate components such as the SELECT clause and FROM clause.
+    /// </remarks>
+    public SelectQuery() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SelectQuery"/> class from the provided SQL query string.
+    /// </summary>
+    /// <param name="query">The SQL select query string.</param>
+    /// <remarks>
+    /// This constructor parses the provided SQL query string and initializes the select query object with its components, such as SELECT, FROM, WHERE, GROUP BY, HAVING, and ORDER BY clauses.
+    /// The query string may contain additional clauses such as WITH, WINDOW, and LIMIT, which are also parsed and initialized if present.
+    /// </remarks>
+    public SelectQuery(string query)
+    {
+        var parsedQuery = SelectQueryParser.Parse(query);
+        WithClause = parsedQuery.WithClause;
+        SelectClause = parsedQuery.SelectClause;
+        FromClause = parsedQuery.FromClause;
+        WhereClause = parsedQuery.WhereClause;
+        GroupClause = parsedQuery.GroupClause;
+        HavingClause = parsedQuery.HavingClause;
+        WindowClause = parsedQuery.WindowClause;
+        OperatableQueries = parsedQuery.OperatableQueries;
+        OrderClause = parsedQuery.OrderClause;
+        LimitClause = parsedQuery.LimitClause;
+    }
+
+    /// <summary>
+    /// Gets or sets the WITH clause of the select query.
+    /// Common Table Expressions (CTE) are available.
+    /// </summary>
+    public WithClause? WithClause { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the SELECT clause of the select query.
+    /// The SELECT clause specifies which columns to retrieve from the database.
+    /// </summary>
+    public SelectClause? SelectClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the FROM clause of the select query.
+    /// The FROM clause specifies the table, view, CTE (Common Table Expression), or subquery from which to retrieve data.
+    /// </summary>
+    public FromClause? FromClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the WHERE clause of the select query.
+    /// The WHERE clause specifies the conditions that must be met for a row to be returned by the query.
+    /// </summary>
+    public WhereClause? WhereClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the GROUP BY clause of the select query.
+    /// The GROUP BY clause is used to group rows that have the same values into summary rows.
+    /// </summary>
+    public GroupClause? GroupClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the HAVING clause of the select query.
+    /// The HAVING clause is used to filter groups that appear in the result set, typically used in conjunction with the GROUP BY clause.
+    /// </summary>
+    public HavingClause? HavingClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the WINDOW clause of the select query.
+    /// The WINDOW clause defines a window or set of rows for a query result.
+    /// </summary>
+    public WindowClause? WindowClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the comment clause of the select clause.
+    /// </summary>
+    /// <remarks>
+    /// A comment that is output before the selection clause. It is suitable for indicating the nature of the selection query.
+    /// Since it is output after the With clause, it is less visible than the HeaderCommentClause.
+    /// </remarks>
+    [IgnoreMember]
+    public CommentClause? CommentClause { get; set; }
+
+    /// <summary>
+    /// Gets or sets the comment clause for the select query.
+    /// This is printed before the With clause, which can be useful for debugging.
+    /// </summary>
+    /// <remarks>
+    /// This is printed before the With clause and is useful for debugging.
+    /// However, it is not printed if it is not the root query.
+    /// </remarks>
+    [IgnoreMember]
+    public CommentClause? HeaderCommentClause { get; set; }
+
+    public void AddHeaderComment(string comment)
+    {
+        HeaderCommentClause ??= new CommentClause();
+        HeaderCommentClause.Add(comment);
+    }
+
+    public IList<IQuerySource> GetQuerySources()
+    {
+        var commonTables = GetCommonTables().ToList();
+        var sources = new List<IQuerySource>();
+        var lst = CreateQuerySources(ref sources, commonTables, new Numbering(0));
+
+        return sources;
+    }
+
+    private IList<IQuerySource> CreateQuerySources(ref List<IQuerySource> sources, IList<CommonTable> commonTables, Numbering numbering)
+    {
+        if (FromClause == null) return new List<IQuerySource>();
+
+        var currentSources = new List<IQuerySource>();
+
+        var hasRelation = (FromClause.Relations?.Any() ?? false);
+        var columns = GetColumns().ToList();
+
+        if (hasRelation && columns.Any(x => string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+        {
+            var cols = string.Join(", ", columns.Where(x => string.IsNullOrEmpty(x.TableAlias)).Select(x => x.Column).Distinct());
+            throw new InvalidProgramException($"There are columns whose table alias names cannot be parsed: {cols}.");
+        }
+
+        foreach (var source in GetQuerySourceSelectableTables())
+        {
+            if (sources.Where(x => x.Source == source).Any())
+            {
+                var qs = sources.Where(x => x.Source == source).First();
+                currentSources.Add(qs);
+            }
+            else if (source.Table.TryGetSelectQuery(out var query))
+            {
+                var qs = DisassembleQuerySources(ref sources, source, query, commonTables, numbering, SourceType.SubQuery);
+                currentSources.Add(qs);
+            }
+            else if (source.Table is PhysicalTable table && commonTables.Any(x => x.Alias == table.GetTableFullName()))
+            {
+                // disassemble cte
+                var ct = commonTables.First(x => x.Alias == table.GetTableFullName());
+
+                if (ct.IsSelectQuery)
+                {
+                    // select query
+
+                    // Only those declared before this will be recognized as CTEs
+                    var id = commonTables.IndexOf(ct);
+                    var ctes = commonTables.Where((item, index) => index < id).ToList();
+
+                    var commonQuery = commonTables.First(x => x.Alias == table.GetTableFullName()).GetSelectQuery();
+                    var qs = DisassembleQuerySources(ref sources, source, commonQuery, ctes, numbering, SourceType.CommonTableExtension);
+                    currentSources.Add(qs);
+                }
+                else if (ct.Table is VirtualTable vt && vt.Query is ValuesQuery && ct.ColumnAliases != null)
+                {
+                    // values query
+                    var names = ct.ColumnAliases.OfType<ColumnValue>().Select(x => x.Column).ToHashSet();
+
+                    var qs = new QuerySource(numbering.GetNext(), names, this, source, SourceType.ValuesQuery);
+                    sources.Add(qs);
+                    currentSources.Add(qs);
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
+            else
+            {
+                var cname = columns
+                    .Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+                    .Select(x => x.Column)
+                    .ToHashSet();
+
+                var qs = new QuerySource(numbering.GetNext(), cname, this, source, SourceType.PhysicalTable);
+                sources.Add(qs);
+                currentSources.Add(qs);
+            }
+        }
+
+        // ex. union query
+        foreach (var item in OperatableQueries.Select(x => x.Query).OfType<SelectQuery>())
+        {
+            foreach (var qs in item.CreateQuerySources(ref sources, commonTables, numbering))
+            {
+                currentSources.Add(qs);
+            }
+        }
+
+        return currentSources;
+    }
+
+    private IQuerySource DisassembleQuerySources(ref List<IQuerySource> sources, SelectableTable source, SelectQuery query, IList<CommonTable> commonTables, Numbering numbering, SourceType type)
+    {
+        var index = numbering.GetNext();
+
+        var parents = query.CreateQuerySources(ref sources, commonTables, numbering);
+
+        var cname = query.GetColumnNames().ToList();
+
+        // decode wild card
+        if (cname.Contains("*"))
+        {
+            var allColumns = new Dictionary<string, IEnumerable<string>>();
+            foreach (var nestedSource in parents)
+            {
+                allColumns[nestedSource.Alias] = nestedSource.ColumnNames;
+            }
+
+            cname.Remove("*");
+
+            var wilds = query.SelectClause!.Where(x => x.Alias == "*");
+            foreach (var wild in wilds.Select(x => x.Value).OfType<ColumnValue>())
+            {
+                if (string.IsNullOrEmpty(wild.TableAlias))
+                {
+                    // all
+                    cname.AddRange(allColumns.SelectMany(x => x.Value));
+                    break;
+                }
+                else
+                {
+                    //table all
+                    cname.AddRange(allColumns[wild.TableAlias]);
+                }
+            }
+        }
+
+        // If not available, infer the column names from your query
+        if (!cname.Any() && FromClause != null)
+        {
+            var hasRelation = (FromClause.Relations?.Any() ?? false);
+            var columns = GetColumns().ToList();
+
+            cname = columns
+                .Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+                .Select(x => x.Column)
+                .ToList();
+        }
+
+        var qs = new QuerySource(index, cname.ToHashSet(), this, source, type);
+
+        foreach (var item in parents)
+        {
+            item.References.Add(qs);
+        }
+        sources.Add(qs);
+
+        return qs;
+    }
+
+    private IEnumerable<SelectableTable> GetQuerySourceSelectableTables()
+    {
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetSelectableTables())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetSelectableTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+    {
+        // If this is a root query, a header comment is printed on the first line.
+        if (parent == null && HeaderCommentClause != null)
+        {
+            foreach (var item in HeaderCommentClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (parent == null && WithClause != null)
+        {
+            var commonTables = GetCommonTables();
+            foreach (var item in WithClause.GetTokens(parent, commonTables))
+            {
+                yield return item;
+            }
+        }
+
+        // Comments will be unified to be displayed just before the selected section.
+        if (CommentClause != null)
+        {
+            foreach (var item in CommentClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (SelectClause == null)
+        {
+            // If SelectClause is not specified,
+            // all columns are assumed to be selected.
+            var clause = Token.Reserved(this, parent, "select");
+            yield return clause;
+            yield return new Token(this, clause, "*");
+        }
+        else
+        {
+            foreach (var item in SelectClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (FromClause == null) yield break;
+
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetTokens(parent))
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override WithClause? GetWithClause() => WithClause;
+
+    /// <inheritdoc/>
+    public override SelectClause? GetSelectClause() => SelectClause;
+
+    /// <inheritdoc/>
+    public override SelectQuery GetOrNewSelectQuery() => this;
+
+    /// <inheritdoc/>
+    public override IEnumerable<QueryParameter> GetInnerParameters()
+    {
+        var fromClauseParameters = FromClause?.GetParameters();
+        if (fromClauseParameters != null)
+        {
+            foreach (var item in fromClauseParameters)
+            {
+                yield return item;
+            }
+        }
+
+        var whereClauseParameters = WhereClause?.GetParameters();
+        if (whereClauseParameters != null)
+        {
+            foreach (var item in whereClauseParameters)
+            {
+                yield return item;
+            }
+        }
+
+        var groupClauseParameters = GroupClause?.GetParameters();
+        if (groupClauseParameters != null)
+        {
+            foreach (var item in groupClauseParameters)
+            {
+                yield return item;
+            }
+        }
+
+        var havingClauseParameters = HavingClause?.GetParameters();
+        if (havingClauseParameters != null)
+        {
+            foreach (var item in havingClauseParameters)
+            {
+                yield return item;
+            }
+        }
+
+        var windowClauseParameters = WindowClause?.GetParameters();
+        if (windowClauseParameters != null)
+        {
+            foreach (var item in windowClauseParameters)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
+    {
+        var vt = new VirtualTable(this);
+        if (columnAliases != null)
+        {
+            return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
+        }
+        return new SelectableTable(vt, "q");
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<string> GetColumnNames()
+    {
+        if (SelectClause == null) return Enumerable.Empty<string>();
+        return SelectClause.Select(x => x.Alias);
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+
+        yield return this;
+
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<SelectableItem> GetSelectableItems()
+    {
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<SelectableTable> GetSelectableTables()
+    {
+        if (FromClause == null) yield break;
+        foreach (var item in FromClause.GetSelectableTables()) yield return item;
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<CommonTable> GetCommonTables()
+    {
+        if (WithClause != null)
+        {
+            foreach (var item in WithClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        foreach (var oq in OperatableQueries)
+        {
+            foreach (var item in oq.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    public override IEnumerable<ColumnValue> GetColumns()
+    {
+        if (SelectClause != null)
+        {
+            foreach (var item in SelectClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (FromClause != null)
+        {
+            foreach (var item in FromClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (WhereClause != null)
+        {
+            foreach (var item in WhereClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (GroupClause != null)
+        {
+            foreach (var item in GroupClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (HavingClause != null)
+        {
+            foreach (var item in HavingClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (WindowClause != null)
+        {
+            foreach (var item in WindowClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (OrderClause != null)
+        {
+            foreach (var item in OrderClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+        if (LimitClause != null)
+        {
+            foreach (var item in LimitClause.GetColumns())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <summary>
+    /// This method tries to convert the SelectQuery instance to a ValuesQuery instance.
+    /// </summary>
+    /// <param name="query">The resulting ValuesQuery if conversion succeeds; otherwise, default.</param>
+    /// <returns>True if the conversion succeeds; otherwise, false.</returns>
+    public bool TryToValuesQuery([MaybeNullWhen(false)] out ValuesQuery query)
+    {
+        query = default;
+        if (SelectClause is null) return false;
+
+        var row = new ValueCollection(SelectClause.Select(x => x.Value).ToList<ValueBase>());
+        var q = new ValuesQuery();
+        q.Rows.Add(row);
+
+        foreach (var item in OperatableQueries)
+        {
+            if (item.Query is SelectQuery sq)
+            {
+                if (sq.TryToValuesQuery(out var vq))
+                {
+                    q.Rows.AddRange(vq.Rows);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else if (item.Query is ValuesQuery vq)
+            {
+                q.Rows.AddRange(vq.Rows);
+            }
+        }
+
+        // Conversion is not possible if the number of columns is different.
+        if (q.Rows.Min(x => x.Count()) != q.Rows.Max(x => x.Count()))
+        {
+            return false;
+        }
+
+        query = q;
+        return true;
+    }
+
+    private class Numbering(int startIndex)
+    {
+        public int Current { get; private set; } = startIndex;
+        public int GetNext()
+        {
+            Current++;
+            return Current;
+        }
+    }
+
+    /// <summary>
+    /// Returns a select query that references itself as a CTE (Common Table Expression).
+    /// </summary>
+    /// <param name="name">The name of the CTE.</param>
+    /// <param name="alias">
+    /// The alias to use. If omitted, the select clause will use a wildcard.
+    /// </param>
+    /// <returns>The modified select query with the CTE reference.</returns>
+    /// <exception cref="InvalidProgramException">
+    /// Thrown if a CTE with the same name already exists.
+    /// </exception>
+    public SelectQuery ToCTEQuery(string name, string alias = "")
+    {
+        if (GetCommonTables().Where(x => x.Alias.IsEqualNoCase(name)).Any())
+        {
+            throw new InvalidProgramException($"A CTE with the same name already exists. Name: {name}");
+        }
+
+        var (q, t) = this.ToCTE(name);
+
+        if (string.IsNullOrEmpty(alias))
+        {
+            q.From(t).As(name);
+            q.SelectAll();
+        }
+        else
+        {
+            q.From(t).As(alias);
+            GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
+        }
+
+        return q;
+    }
+
+    /// <summary>
+    /// Returns a select query that references itself as a subquery.
+    /// </summary>
+    /// <param name="alias">The alias to use for the subquery.</param>
+    /// <returns>The modified select query with the subquery reference.</returns>
+    public SelectQuery ToSubQuery(string alias)
+    {
+        var q = new SelectQuery();
+        var (f, t) = q.From(this).As(alias);
+
+        GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
+
+        return q;
+    }
+
+    [Obsolete("use AddCteQuery method")]
+    public SelectQuery AddCTEQuery(string query, string alias)
+    {
+        return AddCteQuery(query, alias);
+    }
+
+    public SelectQuery AddCteQuery(string query, string alias)
+    {
+        this.With(query).As(alias);
+        return this;
+    }
+
+    public SelectQuery AddFrom(string table, string alias)
+    {
+        if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
+        FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
+        return this;
+    }
+
+    public SelectQuery AddFrom(string table, string alias, IEnumerable<string> selectColumns)
+    {
+        if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
+        FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
+        selectColumns.ForEach(x => this.Select(new ColumnValue(alias, x)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a column to the select clause.
+    /// </summary>
+    /// <param name="column">The column information.</param>
+    /// <param name="alias">The alias name for the column.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddSelect(string column, string alias)
+    {
+        this.Select(column).As(alias);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a column to the select clause.
+    /// </summary>
+    /// <param name="column">The column information.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddSelect(string column)
+    {
+        var val = ValueParser.Parse(column);
+        if (val is ColumnValue c)
+        {
+            this.Select(c).As(c.GetDefaultName());
+            return this;
+        }
+        throw new InvalidOperationException();
+    }
+
+    public SelectQuery AddSelectAll(string tableName)
+    {
+        var t = GetSelectableTables().Where(x => x.Table.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName)).FirstOrDefault();
+        if (t == null)
+        {
+            throw new InvalidProgramException($"Table not found. table:{tableName}");
+        }
+
+        GetQuerySources()
+            .Where(x => x.Source.Equals(t))
+            .GetRootsBySource()
+            .EnsureAny()
+            .ForEach(x =>
+            {
+                x.ColumnNames.ForEach(column => this.Select(x.Alias, column));
+            });
+        return this;
+    }
+
+    public SelectQuery RenameSelect(string columnAliasName, string newAliasName)
+    {
+        var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+        c.SetAlias(newAliasName);
+        return this;
+    }
+
+    public SelectQuery RemoveSelect(string selectableColumnName)
+    {
+        var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(selectableColumnName)).First();
+        SelectClause!.Remove(c);
+        return this;
+    }
+
+    public SelectQuery RemoveSelectAll()
+    {
+        SelectClause = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Searches for the specified column and overrides it.
+    /// </summary>
+    /// <param name="columnAliasName">The name of the column to search for.</param>
+    /// <param name="overrider">The function to modify the column value.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery OverrideSelect(string columnAliasName, Func<IQuerySource, string, string> overrider)
+    {
+        GetQuerySources()
+            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
+            .EnsureAny($"column alias:{columnAliasName}")
+            .GetRootsBySource()
+            .ForEach(x =>
+            {
+                var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+                //override
+                si.Value = ValueParser.Parse(overrider(x, si.Value.ToOneLineText()));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Searches for the specified column in the specified table and overrides it.
+    /// </summary>
+    /// <param name="tableName">The name of the table to search in.</param>
+    /// <param name="columnAliasName">The name of the column to search for.</param>
+    /// <param name="overrider">The function to modify the column value.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery OverrideSelect(string tableName, string columnAliasName, Func<IQuerySource, SelectableItem, string> overrider)
+    {
+        GetQuerySources()
+            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
+            .EnsureAny($"table:{tableName}")
+            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
+            .EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column alias:{columnAliasName}")
+            .GetRootsBySource()
+            .EnsureAny()
+            .ForEach(x =>
+            {
+                var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+                //override
+                si.Value = ValueParser.Parse(overrider(x, si));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="columnName">The name of the column to search in.</param>
+    /// <param name="adder">The function to create the search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(string columnName, Func<IQuerySource, string> adder)
+    {
+        GetQuerySources()
+            .Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+            .EnsureAny($"column:{columnName}")
+            .GetRootsBySource()
+            .ForEach(x =>
+            {
+                x.Query.Where(adder(x));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="columnName">The name of the column to search in.</param>
+    /// <param name="adder">The function to create the search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(string columnName, Func<IQuerySource, string, string> adder)
+    {
+        GetQuerySources()
+            .Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+            .EnsureAny($"column:{columnName}")
+            .GetRootsBySource()
+            .ForEach(x =>
+            {
+                x.Query.Where(adder(x, columnName));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="condition">search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(string condition)
+    {
+        this.Where(condition);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="adder">The function to create the search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(Func<string> adder)
+    {
+        this.Where(adder());
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="tableName">The name of the table to search in.</param>
+    /// <param name="columnName">The name of the column to search in.</param>
+    /// <param name="adder">The function to create the search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string> adder)
+    {
+        GetQuerySources()
+            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
+            .EnsureAny($"table:{tableName}")
+            .Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+            .EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
+            .GetRootsBySource()
+            .ForEach(x =>
+            {
+                x.Query.Where(adder(x));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a search condition.
+    /// </summary>
+    /// <param name="tableName">The name of the table to search in.</param>
+    /// <param name="columnName">The name of the column to search in.</param>
+    /// <param name="adder">The function to create the search condition.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string, string> adder)
+    {
+        GetQuerySources()
+            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
+            .EnsureAny($"table:{tableName}")
+            .Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+            .EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
+            .GetRootsBySource()
+            .ForEach(x =>
+            {
+                x.Query.Where(adder(x, columnName));
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an EXISTS clause.
+    /// </summary>
+    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
+    /// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
+    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+    {
+        GetQuerySources()
+            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+            .EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
+            .GetRootsBySource()
+            .ForEach(qs =>
+            {
+                qs.Query.Where(() =>
+                {
+                    var sq = new SelectQuery($"select * from {validationTableName} as x");
+                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+                    return sq.ToExists();
+                });
+                action?.Invoke(qs);
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an EXISTS clause.
+    /// </summary>
+    /// <param name="sourceTableName">The name of the table to search in.</param>
+    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
+    /// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
+    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+    {
+        GetQuerySources()
+            .Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName) || x.Alias.IsEqualNoCase(sourceTableName))
+            .EnsureAny($"table:{sourceTableName}")
+            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+            .EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
+            .GetRootsBySource()
+            .EnsureAny()
+            .ForEach(qs =>
+            {
+                qs.Query.Where(() =>
+                {
+                    var sq = new SelectQuery($"select * from {validationTableName} as x");
+                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+                    return sq.ToExists();
+                });
+                action?.Invoke(qs);
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a NOT EXISTS clause.
+    /// </summary>
+    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
+    /// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
+    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddNotExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+    {
+        GetQuerySources()
+            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+            .EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
+            .GetRootsBySource()
+            .ForEach(qs =>
+            {
+                qs.Query.Where(() =>
+                {
+                    var sq = new SelectQuery($"select * from {validationTableName} as x");
+                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+                    return sq.ToNotExists();
+                });
+                action?.Invoke(qs);
+            });
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a NOT EXISTS clause.
+    /// </summary>
+    /// <param name="sourceTableName">The name of the table to search in.</param>
+    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
+    /// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
+    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+    /// <returns>The modified select query.</returns>
+    public SelectQuery AddNotExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+    {
+        GetQuerySources()
+            .Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName))
+            .EnsureAny($"table:{sourceTableName}")
+            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+            .EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
+            .GetRootsBySource()
+            .ForEach(qs =>
+            {
+                qs.Query.Where(() =>
+                {
+                    var sq = new SelectQuery($"select * from {validationTableName} as x");
+                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+                    return sq.ToNotExists();
+                });
+                action?.Invoke(qs);
+            });
+
+        return this;
+    }
+
+    public SelectQuery AddJoin(string joinType, string table, string alias, string condition)
+    {
+        var f = FromClause!;
+        var t = TableParser.Parse(table);
+        var r = f.Join(t.ToSelectable(alias), joinType);
+        r.On(condition);
+        return this;
+    }
+
+    public SelectQuery AddJoin(string joinType, string table, string alias, Func<string> builder)
+    {
+        var f = FromClause!;
+        var t = TableParser.Parse(table);
+        var r = f.Join(t.ToSelectable(alias), joinType);
+        r.On(builder);
+        return this;
+    }
+
+    public SelectQuery AddSelectQuery(string jointType, Func<SelectQuery, SelectQuery> builder)
+    {
+        AddOperatableValue(jointType, builder(this));
+        return this;
+    }
+
+    public SelectQuery ImportCTEQueries(SelectQuery from)
+    {
+        from.GetCommonTables().ForEach(x => this.With(x));
+        return this;
+    }
+
+    public SelectQuery AddParameter(QueryParameter prm)
+    {
+        Parameters.Add(prm);
+        return this;
+    }
+
+    public SelectQuery AddOrder(string columnName, Func<IQuerySource, string, string> adder)
+    {
+        GetQuerySources()
+            .Where(x => x.Query.Equals(this))
+            .ForEach(x =>
+            {
+                x.Query.OrderClause ??= new();
+                x.Query.OrderClause.Add(SortableItemParser.Parse(adder(x, columnName)));
+            });
+
+        return this;
+    }
+
+    public SelectQuery FilterInColumns(IEnumerable<string> columnNames)
+    {
+        if (SelectClause == null) throw new NullReferenceException(nameof(SelectClause));
+        SelectClause.FilterInColumns(columnNames);
+        return this;
+    }
 }

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -21,1264 +21,1269 @@ namespace Carbunql;
 [MessagePackObject(keyAsPropertyName: true)]
 public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SelectQuery"/> class.
-    /// </summary>
-    /// <remarks>
-    /// This constructor initializes a new instance of the SelectQuery class in an empty state.
-    /// After instantiation, additional processing is required to populate components such as the SELECT clause and FROM clause.
-    /// </remarks>
-    public SelectQuery() { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SelectQuery"/> class from the provided SQL query string.
-    /// </summary>
-    /// <param name="query">The SQL select query string.</param>
-    /// <remarks>
-    /// This constructor parses the provided SQL query string and initializes the select query object with its components, such as SELECT, FROM, WHERE, GROUP BY, HAVING, and ORDER BY clauses.
-    /// The query string may contain additional clauses such as WITH, WINDOW, and LIMIT, which are also parsed and initialized if present.
-    /// </remarks>
-    public SelectQuery(string query)
-    {
-        var parsedQuery = SelectQueryParser.Parse(query);
-        WithClause = parsedQuery.WithClause;
-        SelectClause = parsedQuery.SelectClause;
-        FromClause = parsedQuery.FromClause;
-        WhereClause = parsedQuery.WhereClause;
-        GroupClause = parsedQuery.GroupClause;
-        HavingClause = parsedQuery.HavingClause;
-        WindowClause = parsedQuery.WindowClause;
-        OperatableQueries = parsedQuery.OperatableQueries;
-        OrderClause = parsedQuery.OrderClause;
-        LimitClause = parsedQuery.LimitClause;
-    }
-
-    /// <summary>
-    /// Gets or sets the WITH clause of the select query.
-    /// Common Table Expressions (CTE) are available.
-    /// </summary>
-    public WithClause? WithClause { get; set; } = new();
-
-    /// <summary>
-    /// Gets or sets the SELECT clause of the select query.
-    /// The SELECT clause specifies which columns to retrieve from the database.
-    /// </summary>
-    public SelectClause? SelectClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the FROM clause of the select query.
-    /// The FROM clause specifies the table, view, CTE (Common Table Expression), or subquery from which to retrieve data.
-    /// </summary>
-    public FromClause? FromClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the WHERE clause of the select query.
-    /// The WHERE clause specifies the conditions that must be met for a row to be returned by the query.
-    /// </summary>
-    public WhereClause? WhereClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the GROUP BY clause of the select query.
-    /// The GROUP BY clause is used to group rows that have the same values into summary rows.
-    /// </summary>
-    public GroupClause? GroupClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the HAVING clause of the select query.
-    /// The HAVING clause is used to filter groups that appear in the result set, typically used in conjunction with the GROUP BY clause.
-    /// </summary>
-    public HavingClause? HavingClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the WINDOW clause of the select query.
-    /// The WINDOW clause defines a window or set of rows for a query result.
-    /// </summary>
-    public WindowClause? WindowClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the comment clause of the select clause.
-    /// </summary>
-    /// <remarks>
-    /// A comment that is output before the selection clause. It is suitable for indicating the nature of the selection query.
-    /// Since it is output after the With clause, it is less visible than the HeaderCommentClause.
-    /// </remarks>
-    [IgnoreMember]
-    public CommentClause? CommentClause { get; set; }
-
-    /// <summary>
-    /// Gets or sets the comment clause for the select query.
-    /// This is printed before the With clause, which can be useful for debugging.
-    /// </summary>
-    /// <remarks>
-    /// This is printed before the With clause and is useful for debugging.
-    /// However, it is not printed if it is not the root query.
-    /// </remarks>
-    [IgnoreMember]
-    public CommentClause? HeaderCommentClause { get; set; }
-
-    public void AddHeaderComment(string comment)
-    {
-        HeaderCommentClause ??= new CommentClause();
-        HeaderCommentClause.Add(comment);
-    }
-
-    public IList<IQuerySource> GetQuerySources()
-    {
-        var commonTables = GetCommonTables().ToList();
-        var sources = new List<IQuerySource>();
-        var lst = CreateQuerySources(ref sources, commonTables, new Numbering(0));
-
-        return sources;
-    }
-
-    private IList<IQuerySource> CreateQuerySources(ref List<IQuerySource> sources, IList<CommonTable> commonTables, Numbering numbering)
-    {
-        if (FromClause == null) return new List<IQuerySource>();
-
-        var currentSources = new List<IQuerySource>();
-
-        var hasRelation = (FromClause.Relations?.Any() ?? false);
-        var columns = GetColumns().ToList();
-
-        if (hasRelation && columns.Any(x => string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-        {
-            var cols = string.Join(", ", columns.Where(x => string.IsNullOrEmpty(x.TableAlias)).Select(x => x.Column).Distinct());
-            throw new InvalidProgramException($"There are columns whose table alias names cannot be parsed: {cols}.");
-        }
-
-        foreach (var source in GetQuerySourceSelectableTables())
-        {
-            if (sources.Where(x => x.Source == source).Any())
-            {
-                var qs = sources.Where(x => x.Source == source).First();
-                currentSources.Add(qs);
-            }
-            else if (source.Table.TryGetSelectQuery(out var query))
-            {
-                var qs = DisassembleQuerySources(ref sources, source, query, commonTables, numbering, SourceType.SubQuery);
-                currentSources.Add(qs);
-            }
-            else if (source.Table is PhysicalTable table && commonTables.Any(x => x.Alias == table.GetTableFullName()))
-            {
-                // disassemble cte
-                var ct = commonTables.First(x => x.Alias == table.GetTableFullName());
-
-                if (ct.IsSelectQuery)
-                {
-                    // select query
-
-                    // Only those declared before this will be recognized as CTEs
-                    var id = commonTables.IndexOf(ct);
-                    var ctes = commonTables.Where((item, index) => index < id).ToList();
-
-                    var commonQuery = commonTables.First(x => x.Alias == table.GetTableFullName()).GetSelectQuery();
-                    var qs = DisassembleQuerySources(ref sources, source, commonQuery, ctes, numbering, SourceType.CommonTableExtension);
-                    currentSources.Add(qs);
-                }
-                else if (ct.Table is VirtualTable vt && vt.Query is ValuesQuery && ct.ColumnAliases != null)
-                {
-                    // values query
-                    var names = ct.ColumnAliases.OfType<ColumnValue>().Select(x => x.Column).ToHashSet();
-
-                    var qs = new QuerySource(numbering.GetNext(), names, this, source, SourceType.ValuesQuery);
-                    sources.Add(qs);
-                    currentSources.Add(qs);
-                }
-                else
-                {
-                    throw new NotSupportedException();
-                }
-            }
-            else
-            {
-                var cname = columns
-                    .Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-                    .Select(x => x.Column)
-                    .ToHashSet();
-
-                var qs = new QuerySource(numbering.GetNext(), cname, this, source, SourceType.PhysicalTable);
-                sources.Add(qs);
-                currentSources.Add(qs);
-            }
-        }
-
-        // ex. union query
-        foreach (var item in OperatableQueries.Select(x => x.Query).OfType<SelectQuery>())
-        {
-            foreach (var qs in item.CreateQuerySources(ref sources, commonTables, numbering))
-            {
-                currentSources.Add(qs);
-            }
-        }
-
-        return currentSources;
-    }
-
-    private IQuerySource DisassembleQuerySources(ref List<IQuerySource> sources, SelectableTable source, SelectQuery query, IList<CommonTable> commonTables, Numbering numbering, SourceType type)
-    {
-        var index = numbering.GetNext();
-
-        var parents = query.CreateQuerySources(ref sources, commonTables, numbering);
-
-        var cname = query.GetColumnNames().ToList();
-
-        // decode wild card
-        if (cname.Contains("*"))
-        {
-            var allColumns = new Dictionary<string, IEnumerable<string>>();
-            foreach (var nestedSource in parents)
-            {
-                allColumns[nestedSource.Alias] = nestedSource.ColumnNames;
-            }
-
-            cname.Remove("*");
-
-            var wilds = query.SelectClause!.Where(x => x.Alias == "*");
-            foreach (var wild in wilds.Select(x => x.Value).OfType<ColumnValue>())
-            {
-                if (string.IsNullOrEmpty(wild.TableAlias))
-                {
-                    // all
-                    cname.AddRange(allColumns.SelectMany(x => x.Value));
-                    break;
-                }
-                else
-                {
-                    //table all
-                    cname.AddRange(allColumns[wild.TableAlias]);
-                }
-            }
-        }
-
-        // If not available, infer the column names from your query
-        if (!cname.Any() && FromClause != null)
-        {
-            var hasRelation = (FromClause.Relations?.Any() ?? false);
-            var columns = GetColumns().ToList();
-
-            cname = columns
-                .Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
-                .Select(x => x.Column)
-                .ToList();
-        }
-
-        var qs = new QuerySource(index, cname.ToHashSet(), this, source, type);
-
-        foreach (var item in parents)
-        {
-            item.References.Add(qs);
-        }
-        sources.Add(qs);
-
-        return qs;
-    }
-
-    private IEnumerable<SelectableTable> GetQuerySourceSelectableTables()
-    {
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetSelectableTables())
-            {
-                yield return item;
-            }
-        }
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetSelectableTables())
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public override IEnumerable<Token> GetCurrentTokens(Token? parent)
-    {
-        // If this is a root query, a header comment is printed on the first line.
-        if (parent == null && HeaderCommentClause != null)
-        {
-            foreach (var item in HeaderCommentClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (parent == null && WithClause != null)
-        {
-            var commonTables = GetCommonTables();
-            foreach (var item in WithClause.GetTokens(parent, commonTables))
-            {
-                yield return item;
-            }
-        }
-
-        // Comments will be unified to be displayed just before the selected section.
-        if (CommentClause != null)
-        {
-            foreach (var item in CommentClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (SelectClause == null)
-        {
-            // If SelectClause is not specified,
-            // all columns are assumed to be selected.
-            var clause = Token.Reserved(this, parent, "select");
-            yield return clause;
-            yield return new Token(this, clause, "*");
-        }
-        else
-        {
-            foreach (var item in SelectClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (FromClause == null) yield break;
-
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (GroupClause != null)
-        {
-            foreach (var item in GroupClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (HavingClause != null)
-        {
-            foreach (var item in HavingClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-
-        if (WindowClause != null)
-        {
-            foreach (var item in WindowClause.GetTokens(parent))
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public override WithClause? GetWithClause() => WithClause;
-
-    /// <inheritdoc/>
-    public override SelectClause? GetSelectClause() => SelectClause;
-
-    /// <inheritdoc/>
-    public override SelectQuery GetOrNewSelectQuery() => this;
-
-    /// <inheritdoc/>
-    public override IEnumerable<QueryParameter> GetInnerParameters()
-    {
-        var fromClauseParameters = FromClause?.GetParameters();
-        if (fromClauseParameters != null)
-        {
-            foreach (var item in fromClauseParameters)
-            {
-                yield return item;
-            }
-        }
-
-        var whereClauseParameters = WhereClause?.GetParameters();
-        if (whereClauseParameters != null)
-        {
-            foreach (var item in whereClauseParameters)
-            {
-                yield return item;
-            }
-        }
-
-        var groupClauseParameters = GroupClause?.GetParameters();
-        if (groupClauseParameters != null)
-        {
-            foreach (var item in groupClauseParameters)
-            {
-                yield return item;
-            }
-        }
-
-        var havingClauseParameters = HavingClause?.GetParameters();
-        if (havingClauseParameters != null)
-        {
-            foreach (var item in havingClauseParameters)
-            {
-                yield return item;
-            }
-        }
-
-        var windowClauseParameters = WindowClause?.GetParameters();
-        if (windowClauseParameters != null)
-        {
-            foreach (var item in windowClauseParameters)
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
-    {
-        var vt = new VirtualTable(this);
-        if (columnAliases != null)
-        {
-            return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
-        }
-        return new SelectableTable(vt, "q");
-    }
-
-    /// <inheritdoc/>
-    public override IEnumerable<string> GetColumnNames()
-    {
-        if (SelectClause == null) return Enumerable.Empty<string>();
-        return SelectClause.Select(x => x.Alias);
-    }
-
-    /// <inheritdoc/>
-    public override IEnumerable<PhysicalTable> GetPhysicalTables()
-    {
-        if (WithClause != null)
-        {
-            foreach (var item in WithClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-
-        if (SelectClause != null)
-        {
-            foreach (var item in SelectClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (GroupClause != null)
-        {
-            foreach (var item in GroupClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (HavingClause != null)
-        {
-            foreach (var item in HavingClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (WindowClause != null)
-        {
-            foreach (var item in WindowClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        foreach (var oq in OperatableQueries)
-        {
-            foreach (var item in oq.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (OrderClause != null)
-        {
-            foreach (var item in OrderClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-        if (LimitClause != null)
-        {
-            foreach (var item in LimitClause.GetPhysicalTables())
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public override IEnumerable<SelectQuery> GetInternalQueries()
-    {
-        if (WithClause != null)
-        {
-            foreach (var item in WithClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-
-        yield return this;
-
-        if (SelectClause != null)
-        {
-            foreach (var item in SelectClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (GroupClause != null)
-        {
-            foreach (var item in GroupClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (HavingClause != null)
-        {
-            foreach (var item in HavingClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (WindowClause != null)
-        {
-            foreach (var item in WindowClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        foreach (var oq in OperatableQueries)
-        {
-            foreach (var item in oq.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (OrderClause != null)
-        {
-            foreach (var item in OrderClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-        if (LimitClause != null)
-        {
-            foreach (var item in LimitClause.GetInternalQueries())
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public IEnumerable<SelectableItem> GetSelectableItems()
-    {
-        if (SelectClause != null)
-        {
-            foreach (var item in SelectClause)
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public IEnumerable<SelectableTable> GetSelectableTables()
-    {
-        if (FromClause == null) yield break;
-        foreach (var item in FromClause.GetSelectableTables()) yield return item;
-    }
-
-    /// <inheritdoc/>
-    public override IEnumerable<CommonTable> GetCommonTables()
-    {
-        if (WithClause != null)
-        {
-            foreach (var item in WithClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (SelectClause != null)
-        {
-            foreach (var item in SelectClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (GroupClause != null)
-        {
-            foreach (var item in GroupClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (HavingClause != null)
-        {
-            foreach (var item in HavingClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (WindowClause != null)
-        {
-            foreach (var item in WindowClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        foreach (var oq in OperatableQueries)
-        {
-            foreach (var item in oq.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (OrderClause != null)
-        {
-            foreach (var item in OrderClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-        if (LimitClause != null)
-        {
-            foreach (var item in LimitClause.GetCommonTables())
-            {
-                yield return item;
-            }
-        }
-    }
-
-    public override IEnumerable<ColumnValue> GetColumns()
-    {
-        if (SelectClause != null)
-        {
-            foreach (var item in SelectClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (FromClause != null)
-        {
-            foreach (var item in FromClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (WhereClause != null)
-        {
-            foreach (var item in WhereClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (GroupClause != null)
-        {
-            foreach (var item in GroupClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (HavingClause != null)
-        {
-            foreach (var item in HavingClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (WindowClause != null)
-        {
-            foreach (var item in WindowClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (OrderClause != null)
-        {
-            foreach (var item in OrderClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-        if (LimitClause != null)
-        {
-            foreach (var item in LimitClause.GetColumns())
-            {
-                yield return item;
-            }
-        }
-    }
-
-    /// <summary>
-    /// This method tries to convert the SelectQuery instance to a ValuesQuery instance.
-    /// </summary>
-    /// <param name="query">The resulting ValuesQuery if conversion succeeds; otherwise, default.</param>
-    /// <returns>True if the conversion succeeds; otherwise, false.</returns>
-    public bool TryToValuesQuery([MaybeNullWhen(false)] out ValuesQuery query)
-    {
-        query = default;
-        if (SelectClause is null) return false;
-
-        var row = new ValueCollection(SelectClause.Select(x => x.Value).ToList<ValueBase>());
-        var q = new ValuesQuery();
-        q.Rows.Add(row);
-
-        foreach (var item in OperatableQueries)
-        {
-            if (item.Query is SelectQuery sq)
-            {
-                if (sq.TryToValuesQuery(out var vq))
-                {
-                    q.Rows.AddRange(vq.Rows);
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else if (item.Query is ValuesQuery vq)
-            {
-                q.Rows.AddRange(vq.Rows);
-            }
-        }
-
-        // Conversion is not possible if the number of columns is different.
-        if (q.Rows.Min(x => x.Count()) != q.Rows.Max(x => x.Count()))
-        {
-            return false;
-        }
-
-        query = q;
-        return true;
-    }
-
-    private class Numbering(int startIndex)
-    {
-        public int Current { get; private set; } = startIndex;
-        public int GetNext()
-        {
-            Current++;
-            return Current;
-        }
-    }
-
-    /// <summary>
-    /// Returns a select query that references itself as a CTE (Common Table Expression).
-    /// </summary>
-    /// <param name="name">The name of the CTE.</param>
-    /// <param name="alias">
-    /// The alias to use. If omitted, the select clause will use a wildcard.
-    /// </param>
-    /// <returns>The modified select query with the CTE reference.</returns>
-    /// <exception cref="InvalidProgramException">
-    /// Thrown if a CTE with the same name already exists.
-    /// </exception>
-    public SelectQuery ToCTEQuery(string name, string alias = "")
-    {
-        if (GetCommonTables().Where(x => x.Alias.IsEqualNoCase(name)).Any())
-        {
-            throw new InvalidProgramException($"A CTE with the same name already exists. Name: {name}");
-        }
-
-        var (q, t) = this.ToCTE(name);
-
-        if (string.IsNullOrEmpty(alias))
-        {
-            q.From(t).As(name);
-            q.SelectAll();
-        }
-        else
-        {
-            q.From(t).As(alias);
-            GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
-        }
-
-        return q;
-    }
-
-    /// <summary>
-    /// Returns a select query that references itself as a subquery.
-    /// </summary>
-    /// <param name="alias">The alias to use for the subquery.</param>
-    /// <returns>The modified select query with the subquery reference.</returns>
-    public SelectQuery ToSubQuery(string alias)
-    {
-        var q = new SelectQuery();
-        var (f, t) = q.From(this).As(alias);
-
-        GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
-
-        return q;
-    }
-
-    [Obsolete("use AddCteQuery method")]
-    public SelectQuery AddCTEQuery(string query, string alias)
-    {
-        return AddCteQuery(query, alias);
-    }
-
-    public SelectQuery AddCteQuery(string query, string alias)
-    {
-        this.With(query).As(alias);
-        return this;
-    }
-
-    public SelectQuery AddFrom(string table, string alias)
-    {
-        if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
-        FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
-        return this;
-    }
-
-    public SelectQuery AddFrom(string table, string alias, IEnumerable<string> selectColumns)
-    {
-        if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
-        FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
-        selectColumns.ForEach(x => this.Select(new ColumnValue(alias, x)));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a column to the select clause.
-    /// </summary>
-    /// <param name="column">The column information.</param>
-    /// <param name="alias">The alias name for the column.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddSelect(string column, string alias)
-    {
-        this.Select(column).As(alias);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a column to the select clause.
-    /// </summary>
-    /// <param name="column">The column information.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddSelect(string column)
-    {
-        var val = ValueParser.Parse(column);
-        if (val is ColumnValue c)
-        {
-            this.Select(c).As(c.GetDefaultName());
-            return this;
-        }
-        throw new InvalidOperationException();
-    }
-
-    public SelectQuery AddSelectAll(string tableName)
-    {
-        var t = GetSelectableTables().Where(x => x.Alias.IsEqualNoCase(tableName)).First();
-
-        GetQuerySources()
-            .Where(x => x.Source.Equals(t))
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                x.ColumnNames.ForEach(column => this.Select(x.Alias, column));
-            });
-        return this;
-    }
-
-    public SelectQuery RenameSelect(string columnName, string newName)
-    {
-        var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).First();
-        c.SetAlias(newName);
-        return this;
-    }
-
-    public SelectQuery RemoveSelect(string columnName)
-    {
-        var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).First();
-        SelectClause!.Remove(c);
-        return this;
-    }
-
-    public SelectQuery RemoveSelectAll()
-    {
-        SelectClause = null;
-        return this;
-    }
-
-    /// <summary>
-    /// Searches for the specified column and overrides it.
-    /// </summary>
-    /// <param name="columnName">The name of the column to search for.</param>
-    /// <param name="overrider">The function to modify the column value.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery OverrideSelect(string columnName, Func<IQuerySource, string, string> overrider)
-    {
-        GetQuerySources()
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).First();
-                //override
-                si.Value = ValueParser.Parse(overrider(x, si.Value.ToOneLineText()));
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Searches for the specified column in the specified table and overrides it.
-    /// </summary>
-    /// <param name="tableName">The name of the table to search in.</param>
-    /// <param name="columnName">The name of the column to search for.</param>
-    /// <param name="overrider">The function to modify the column value.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery OverrideSelect(string tableName, string columnName, Func<IQuerySource, SelectableItem, string> overrider)
-    {
-        GetQuerySources()
-            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).First();
-                //override
-                si.Value = ValueParser.Parse(overrider(x, si));
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="columnName">The name of the column to search in.</param>
-    /// <param name="adder">The function to create the search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(string columnName, Func<IQuerySource, string> adder)
-    {
-        GetQuerySources()
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                if (x.ColumnNames.Where(column => column.IsEqualNoCase(columnName)).Any())
-                {
-                    x.Query.Where(adder(x));
-                }
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="columnName">The name of the column to search in.</param>
-    /// <param name="adder">The function to create the search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(string columnName, Func<IQuerySource, string, string> adder)
-    {
-        GetQuerySources()
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                if (x.ColumnNames.Where(column => column.IsEqualNoCase(columnName)).Any())
-                {
-                    x.Query.Where(adder(x, columnName));
-                }
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="condition">search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(string condition)
-    {
-        this.Where(condition);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="adder">The function to create the search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(Func<string> adder)
-    {
-        this.Where(adder());
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="tableName">The name of the table to search in.</param>
-    /// <param name="columnName">The name of the column to search in.</param>
-    /// <param name="adder">The function to create the search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string> adder)
-    {
-        GetQuerySources()
-            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                x.Query.Where(adder(x));
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a search condition.
-    /// </summary>
-    /// <param name="tableName">The name of the table to search in.</param>
-    /// <param name="columnName">The name of the column to search in.</param>
-    /// <param name="adder">The function to create the search condition.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string, string> adder)
-    {
-        GetQuerySources()
-            .Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
-            .Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnName)).Any())
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(x =>
-            {
-                x.Query.Where(adder(x, columnName));
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an EXISTS clause.
-    /// </summary>
-    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
-    /// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
-    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-    {
-        GetQuerySources()
-            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(qs =>
-            {
-                qs.Query.Where(() =>
-                {
-                    var sq = new SelectQuery($"select * from {validationTableName} as x");
-                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-                    return sq.ToExists();
-                });
-                action?.Invoke(qs);
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an EXISTS clause.
-    /// </summary>
-    /// <param name="sourceTableName">The name of the table to search in.</param>
-    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
-    /// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
-    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-    {
-        GetQuerySources()
-            .Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName))
-            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(qs =>
-            {
-                qs.Query.Where(() =>
-                {
-                    var sq = new SelectQuery($"select * from {validationTableName} as x");
-                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-                    return sq.ToExists();
-                });
-                action?.Invoke(qs);
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a NOT EXISTS clause.
-    /// </summary>
-    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
-    /// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
-    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddNotExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-    {
-        GetQuerySources()
-            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(qs =>
-            {
-                qs.Query.Where(() =>
-                {
-                    var sq = new SelectQuery($"select * from {validationTableName} as x");
-                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-                    return sq.ToNotExists();
-                });
-                action?.Invoke(qs);
-            });
-
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a NOT EXISTS clause.
-    /// </summary>
-    /// <param name="sourceTableName">The name of the table to search in.</param>
-    /// <param name="keyColumnNames">The columns to use for the search condition.</param>
-    /// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
-    /// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
-    /// <returns>The modified select query.</returns>
-    public SelectQuery AddNotExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
-    {
-        GetQuerySources()
-            .Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName))
-            .Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
-            .GetRootsBySource()
-            .EnsureAny()
-            .ForEach(qs =>
-            {
-                qs.Query.Where(() =>
-                {
-                    var sq = new SelectQuery($"select * from {validationTableName} as x");
-                    keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
-                    return sq.ToNotExists();
-                });
-                action?.Invoke(qs);
-            });
-
-        return this;
-    }
-
-    public SelectQuery AddJoin(string joinType, string table, string alias, string condition)
-    {
-        var f = FromClause!;
-        var t = TableParser.Parse(table);
-        var r = f.Join(t.ToSelectable(alias), joinType);
-        r.On(condition);
-        return this;
-    }
-
-    public SelectQuery AddJoin(string joinType, string table, string alias, Func<string> builder)
-    {
-        var f = FromClause!;
-        var t = TableParser.Parse(table);
-        var r = f.Join(t.ToSelectable(alias), joinType);
-        r.On(builder);
-        return this;
-    }
-
-    public SelectQuery AddSelectQuery(string jointType, Func<SelectQuery, SelectQuery> builder)
-    {
-        AddOperatableValue(jointType, builder(this));
-        return this;
-    }
-
-    public SelectQuery ImportCTEQueries(SelectQuery from)
-    {
-        from.GetCommonTables().ForEach(x => this.With(x));
-        return this;
-    }
-
-    public SelectQuery AddParameter(QueryParameter prm)
-    {
-        Parameters.Add(prm);
-        return this;
-    }
-
-    public SelectQuery AddOrder(string columnName, Func<IQuerySource, string, string> adder)
-    {
-        GetQuerySources()
-            .Where(x => x.Query.Equals(this))
-            .ForEach(x =>
-            {
-                x.Query.OrderClause ??= new();
-                x.Query.OrderClause.Add(SortableItemParser.Parse(adder(x, columnName)));
-            });
-
-        return this;
-    }
-
-    public SelectQuery FilterInColumns(IEnumerable<string> columnNames)
-    {
-        if (SelectClause == null) throw new NullReferenceException(nameof(SelectClause));
-        SelectClause.FilterInColumns(columnNames);
-        return this;
-    }
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SelectQuery"/> class.
+	/// </summary>
+	/// <remarks>
+	/// This constructor initializes a new instance of the SelectQuery class in an empty state.
+	/// After instantiation, additional processing is required to populate components such as the SELECT clause and FROM clause.
+	/// </remarks>
+	public SelectQuery() { }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SelectQuery"/> class from the provided SQL query string.
+	/// </summary>
+	/// <param name="query">The SQL select query string.</param>
+	/// <remarks>
+	/// This constructor parses the provided SQL query string and initializes the select query object with its components, such as SELECT, FROM, WHERE, GROUP BY, HAVING, and ORDER BY clauses.
+	/// The query string may contain additional clauses such as WITH, WINDOW, and LIMIT, which are also parsed and initialized if present.
+	/// </remarks>
+	public SelectQuery(string query)
+	{
+		var parsedQuery = SelectQueryParser.Parse(query);
+		WithClause = parsedQuery.WithClause;
+		SelectClause = parsedQuery.SelectClause;
+		FromClause = parsedQuery.FromClause;
+		WhereClause = parsedQuery.WhereClause;
+		GroupClause = parsedQuery.GroupClause;
+		HavingClause = parsedQuery.HavingClause;
+		WindowClause = parsedQuery.WindowClause;
+		OperatableQueries = parsedQuery.OperatableQueries;
+		OrderClause = parsedQuery.OrderClause;
+		LimitClause = parsedQuery.LimitClause;
+	}
+
+	/// <summary>
+	/// Gets or sets the WITH clause of the select query.
+	/// Common Table Expressions (CTE) are available.
+	/// </summary>
+	public WithClause? WithClause { get; set; } = new();
+
+	/// <summary>
+	/// Gets or sets the SELECT clause of the select query.
+	/// The SELECT clause specifies which columns to retrieve from the database.
+	/// </summary>
+	public SelectClause? SelectClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the FROM clause of the select query.
+	/// The FROM clause specifies the table, view, CTE (Common Table Expression), or subquery from which to retrieve data.
+	/// </summary>
+	public FromClause? FromClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the WHERE clause of the select query.
+	/// The WHERE clause specifies the conditions that must be met for a row to be returned by the query.
+	/// </summary>
+	public WhereClause? WhereClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the GROUP BY clause of the select query.
+	/// The GROUP BY clause is used to group rows that have the same values into summary rows.
+	/// </summary>
+	public GroupClause? GroupClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the HAVING clause of the select query.
+	/// The HAVING clause is used to filter groups that appear in the result set, typically used in conjunction with the GROUP BY clause.
+	/// </summary>
+	public HavingClause? HavingClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the WINDOW clause of the select query.
+	/// The WINDOW clause defines a window or set of rows for a query result.
+	/// </summary>
+	public WindowClause? WindowClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the comment clause of the select clause.
+	/// </summary>
+	/// <remarks>
+	/// A comment that is output before the selection clause. It is suitable for indicating the nature of the selection query.
+	/// Since it is output after the With clause, it is less visible than the HeaderCommentClause.
+	/// </remarks>
+	[IgnoreMember]
+	public CommentClause? CommentClause { get; set; }
+
+	/// <summary>
+	/// Gets or sets the comment clause for the select query.
+	/// This is printed before the With clause, which can be useful for debugging.
+	/// </summary>
+	/// <remarks>
+	/// This is printed before the With clause and is useful for debugging.
+	/// However, it is not printed if it is not the root query.
+	/// </remarks>
+	[IgnoreMember]
+	public CommentClause? HeaderCommentClause { get; set; }
+
+	public void AddHeaderComment(string comment)
+	{
+		HeaderCommentClause ??= new CommentClause();
+		HeaderCommentClause.Add(comment);
+	}
+
+	public IList<IQuerySource> GetQuerySources()
+	{
+		var commonTables = GetCommonTables().ToList();
+		var sources = new List<IQuerySource>();
+		var lst = CreateQuerySources(ref sources, commonTables, new Numbering(0));
+
+		return sources;
+	}
+
+	private IList<IQuerySource> CreateQuerySources(ref List<IQuerySource> sources, IList<CommonTable> commonTables, Numbering numbering)
+	{
+		if (FromClause == null) return new List<IQuerySource>();
+
+		var currentSources = new List<IQuerySource>();
+
+		var hasRelation = (FromClause.Relations?.Any() ?? false);
+		var columns = GetColumns().ToList();
+
+		if (hasRelation && columns.Any(x => string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+		{
+			var cols = string.Join(", ", columns.Where(x => string.IsNullOrEmpty(x.TableAlias)).Select(x => x.Column).Distinct());
+			throw new InvalidProgramException($"There are columns whose table alias names cannot be parsed: {cols}.");
+		}
+
+		foreach (var source in GetQuerySourceSelectableTables())
+		{
+			if (sources.Where(x => x.Source == source).Any())
+			{
+				var qs = sources.Where(x => x.Source == source).First();
+				currentSources.Add(qs);
+			}
+			else if (source.Table.TryGetSelectQuery(out var query))
+			{
+				var qs = DisassembleQuerySources(ref sources, source, query, commonTables, numbering, SourceType.SubQuery);
+				currentSources.Add(qs);
+			}
+			else if (source.Table is PhysicalTable table && commonTables.Any(x => x.Alias == table.GetTableFullName()))
+			{
+				// disassemble cte
+				var ct = commonTables.First(x => x.Alias == table.GetTableFullName());
+
+				if (ct.IsSelectQuery)
+				{
+					// select query
+
+					// Only those declared before this will be recognized as CTEs
+					var id = commonTables.IndexOf(ct);
+					var ctes = commonTables.Where((item, index) => index < id).ToList();
+
+					var commonQuery = commonTables.First(x => x.Alias == table.GetTableFullName()).GetSelectQuery();
+					var qs = DisassembleQuerySources(ref sources, source, commonQuery, ctes, numbering, SourceType.CommonTableExtension);
+					currentSources.Add(qs);
+				}
+				else if (ct.Table is VirtualTable vt && vt.Query is ValuesQuery && ct.ColumnAliases != null)
+				{
+					// values query
+					var names = ct.ColumnAliases.OfType<ColumnValue>().Select(x => x.Column).ToHashSet();
+
+					var qs = new QuerySource(numbering.GetNext(), names, this, source, SourceType.ValuesQuery);
+					sources.Add(qs);
+					currentSources.Add(qs);
+				}
+				else
+				{
+					throw new NotSupportedException();
+				}
+			}
+			else
+			{
+				var cname = columns
+					.Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+					.Select(x => x.Column)
+					.ToHashSet();
+
+				var qs = new QuerySource(numbering.GetNext(), cname, this, source, SourceType.PhysicalTable);
+				sources.Add(qs);
+				currentSources.Add(qs);
+			}
+		}
+
+		// ex. union query
+		foreach (var item in OperatableQueries.Select(x => x.Query).OfType<SelectQuery>())
+		{
+			foreach (var qs in item.CreateQuerySources(ref sources, commonTables, numbering))
+			{
+				currentSources.Add(qs);
+			}
+		}
+
+		return currentSources;
+	}
+
+	private IQuerySource DisassembleQuerySources(ref List<IQuerySource> sources, SelectableTable source, SelectQuery query, IList<CommonTable> commonTables, Numbering numbering, SourceType type)
+	{
+		var index = numbering.GetNext();
+
+		var parents = query.CreateQuerySources(ref sources, commonTables, numbering);
+
+		var cname = query.GetColumnNames().ToList();
+
+		// decode wild card
+		if (cname.Contains("*"))
+		{
+			var allColumns = new Dictionary<string, IEnumerable<string>>();
+			foreach (var nestedSource in parents)
+			{
+				allColumns[nestedSource.Alias] = nestedSource.ColumnNames;
+			}
+
+			cname.Remove("*");
+
+			var wilds = query.SelectClause!.Where(x => x.Alias == "*");
+			foreach (var wild in wilds.Select(x => x.Value).OfType<ColumnValue>())
+			{
+				if (string.IsNullOrEmpty(wild.TableAlias))
+				{
+					// all
+					cname.AddRange(allColumns.SelectMany(x => x.Value));
+					break;
+				}
+				else
+				{
+					//table all
+					cname.AddRange(allColumns[wild.TableAlias]);
+				}
+			}
+		}
+
+		// If not available, infer the column names from your query
+		if (!cname.Any() && FromClause != null)
+		{
+			var hasRelation = (FromClause.Relations?.Any() ?? false);
+			var columns = GetColumns().ToList();
+
+			cname = columns
+				.Where(x => x.TableAlias == source.Alias || (!hasRelation && string.IsNullOrEmpty(x.TableAlias) && x.Column != "*"))
+				.Select(x => x.Column)
+				.ToList();
+		}
+
+		var qs = new QuerySource(index, cname.ToHashSet(), this, source, type);
+
+		foreach (var item in parents)
+		{
+			item.References.Add(qs);
+		}
+		sources.Add(qs);
+
+		return qs;
+	}
+
+	private IEnumerable<SelectableTable> GetQuerySourceSelectableTables()
+	{
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetSelectableTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetSelectableTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<Token> GetCurrentTokens(Token? parent)
+	{
+		// If this is a root query, a header comment is printed on the first line.
+		if (parent == null && HeaderCommentClause != null)
+		{
+			foreach (var item in HeaderCommentClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (parent == null && WithClause != null)
+		{
+			var commonTables = GetCommonTables();
+			foreach (var item in WithClause.GetTokens(parent, commonTables))
+			{
+				yield return item;
+			}
+		}
+
+		// Comments will be unified to be displayed just before the selected section.
+		if (CommentClause != null)
+		{
+			foreach (var item in CommentClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (SelectClause == null)
+		{
+			// If SelectClause is not specified,
+			// all columns are assumed to be selected.
+			var clause = Token.Reserved(this, parent, "select");
+			yield return clause;
+			yield return new Token(this, clause, "*");
+		}
+		else
+		{
+			foreach (var item in SelectClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (FromClause == null) yield break;
+
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetTokens(parent))
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public override WithClause? GetWithClause() => WithClause;
+
+	/// <inheritdoc/>
+	public override SelectClause? GetSelectClause() => SelectClause;
+
+	/// <inheritdoc/>
+	public override SelectQuery GetOrNewSelectQuery() => this;
+
+	/// <inheritdoc/>
+	public override IEnumerable<QueryParameter> GetInnerParameters()
+	{
+		var fromClauseParameters = FromClause?.GetParameters();
+		if (fromClauseParameters != null)
+		{
+			foreach (var item in fromClauseParameters)
+			{
+				yield return item;
+			}
+		}
+
+		var whereClauseParameters = WhereClause?.GetParameters();
+		if (whereClauseParameters != null)
+		{
+			foreach (var item in whereClauseParameters)
+			{
+				yield return item;
+			}
+		}
+
+		var groupClauseParameters = GroupClause?.GetParameters();
+		if (groupClauseParameters != null)
+		{
+			foreach (var item in groupClauseParameters)
+			{
+				yield return item;
+			}
+		}
+
+		var havingClauseParameters = HavingClause?.GetParameters();
+		if (havingClauseParameters != null)
+		{
+			foreach (var item in havingClauseParameters)
+			{
+				yield return item;
+			}
+		}
+
+		var windowClauseParameters = WindowClause?.GetParameters();
+		if (windowClauseParameters != null)
+		{
+			foreach (var item in windowClauseParameters)
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public override SelectableTable ToSelectableTable(IEnumerable<string>? columnAliases)
+	{
+		var vt = new VirtualTable(this);
+		if (columnAliases != null)
+		{
+			return new SelectableTable(vt, "q", columnAliases.ToValueCollection());
+		}
+		return new SelectableTable(vt, "q");
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<string> GetColumnNames()
+	{
+		if (SelectClause == null) return Enumerable.Empty<string>();
+		return SelectClause.Select(x => x.Alias);
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<PhysicalTable> GetPhysicalTables()
+	{
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		foreach (var oq in OperatableQueries)
+		{
+			foreach (var item in oq.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (OrderClause != null)
+		{
+			foreach (var item in OrderClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+		if (LimitClause != null)
+		{
+			foreach (var item in LimitClause.GetPhysicalTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<SelectQuery> GetInternalQueries()
+	{
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+
+		yield return this;
+
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		foreach (var oq in OperatableQueries)
+		{
+			foreach (var item in oq.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (OrderClause != null)
+		{
+			foreach (var item in OrderClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+		if (LimitClause != null)
+		{
+			foreach (var item in LimitClause.GetInternalQueries())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<SelectableItem> GetSelectableItems()
+	{
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause)
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <inheritdoc/>
+	public IEnumerable<SelectableTable> GetSelectableTables()
+	{
+		if (FromClause == null) yield break;
+		foreach (var item in FromClause.GetSelectableTables()) yield return item;
+	}
+
+	/// <inheritdoc/>
+	public override IEnumerable<CommonTable> GetCommonTables()
+	{
+		if (WithClause != null)
+		{
+			foreach (var item in WithClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		foreach (var oq in OperatableQueries)
+		{
+			foreach (var item in oq.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (OrderClause != null)
+		{
+			foreach (var item in OrderClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+		if (LimitClause != null)
+		{
+			foreach (var item in LimitClause.GetCommonTables())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	public override IEnumerable<ColumnValue> GetColumns()
+	{
+		if (SelectClause != null)
+		{
+			foreach (var item in SelectClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (FromClause != null)
+		{
+			foreach (var item in FromClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (WhereClause != null)
+		{
+			foreach (var item in WhereClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (GroupClause != null)
+		{
+			foreach (var item in GroupClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (HavingClause != null)
+		{
+			foreach (var item in HavingClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (WindowClause != null)
+		{
+			foreach (var item in WindowClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (OrderClause != null)
+		{
+			foreach (var item in OrderClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+		if (LimitClause != null)
+		{
+			foreach (var item in LimitClause.GetColumns())
+			{
+				yield return item;
+			}
+		}
+	}
+
+	/// <summary>
+	/// This method tries to convert the SelectQuery instance to a ValuesQuery instance.
+	/// </summary>
+	/// <param name="query">The resulting ValuesQuery if conversion succeeds; otherwise, default.</param>
+	/// <returns>True if the conversion succeeds; otherwise, false.</returns>
+	public bool TryToValuesQuery([MaybeNullWhen(false)] out ValuesQuery query)
+	{
+		query = default;
+		if (SelectClause is null) return false;
+
+		var row = new ValueCollection(SelectClause.Select(x => x.Value).ToList<ValueBase>());
+		var q = new ValuesQuery();
+		q.Rows.Add(row);
+
+		foreach (var item in OperatableQueries)
+		{
+			if (item.Query is SelectQuery sq)
+			{
+				if (sq.TryToValuesQuery(out var vq))
+				{
+					q.Rows.AddRange(vq.Rows);
+				}
+				else
+				{
+					return false;
+				}
+			}
+			else if (item.Query is ValuesQuery vq)
+			{
+				q.Rows.AddRange(vq.Rows);
+			}
+		}
+
+		// Conversion is not possible if the number of columns is different.
+		if (q.Rows.Min(x => x.Count()) != q.Rows.Max(x => x.Count()))
+		{
+			return false;
+		}
+
+		query = q;
+		return true;
+	}
+
+	private class Numbering(int startIndex)
+	{
+		public int Current { get; private set; } = startIndex;
+		public int GetNext()
+		{
+			Current++;
+			return Current;
+		}
+	}
+
+	/// <summary>
+	/// Returns a select query that references itself as a CTE (Common Table Expression).
+	/// </summary>
+	/// <param name="name">The name of the CTE.</param>
+	/// <param name="alias">
+	/// The alias to use. If omitted, the select clause will use a wildcard.
+	/// </param>
+	/// <returns>The modified select query with the CTE reference.</returns>
+	/// <exception cref="InvalidProgramException">
+	/// Thrown if a CTE with the same name already exists.
+	/// </exception>
+	public SelectQuery ToCTEQuery(string name, string alias = "")
+	{
+		if (GetCommonTables().Where(x => x.Alias.IsEqualNoCase(name)).Any())
+		{
+			throw new InvalidProgramException($"A CTE with the same name already exists. Name: {name}");
+		}
+
+		var (q, t) = this.ToCTE(name);
+
+		if (string.IsNullOrEmpty(alias))
+		{
+			q.From(t).As(name);
+			q.SelectAll();
+		}
+		else
+		{
+			q.From(t).As(alias);
+			GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
+		}
+
+		return q;
+	}
+
+	/// <summary>
+	/// Returns a select query that references itself as a subquery.
+	/// </summary>
+	/// <param name="alias">The alias to use for the subquery.</param>
+	/// <returns>The modified select query with the subquery reference.</returns>
+	public SelectQuery ToSubQuery(string alias)
+	{
+		var q = new SelectQuery();
+		var (f, t) = q.From(this).As(alias);
+
+		GetColumnNames().ForEach(column => q.Select($"{alias}.{column}").As(column));
+
+		return q;
+	}
+
+	[Obsolete("use AddCteQuery method")]
+	public SelectQuery AddCTEQuery(string query, string alias)
+	{
+		return AddCteQuery(query, alias);
+	}
+
+	public SelectQuery AddCteQuery(string query, string alias)
+	{
+		this.With(query).As(alias);
+		return this;
+	}
+
+	public SelectQuery AddFrom(string table, string alias)
+	{
+		if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
+		FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
+		return this;
+	}
+
+	public SelectQuery AddFrom(string table, string alias, IEnumerable<string> selectColumns)
+	{
+		if (FromClause != null) throw new InvalidOperationException("FromClause is already exists.");
+		FromClause = new FromClause(TableParser.Parse(table).ToSelectable(alias));
+		selectColumns.ForEach(x => this.Select(new ColumnValue(alias, x)));
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a column to the select clause.
+	/// </summary>
+	/// <param name="column">The column information.</param>
+	/// <param name="alias">The alias name for the column.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddSelect(string column, string alias)
+	{
+		this.Select(column).As(alias);
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a column to the select clause.
+	/// </summary>
+	/// <param name="column">The column information.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddSelect(string column)
+	{
+		var val = ValueParser.Parse(column);
+		if (val is ColumnValue c)
+		{
+			this.Select(c).As(c.GetDefaultName());
+			return this;
+		}
+		throw new InvalidOperationException();
+	}
+
+	public SelectQuery AddSelectAll(string tableName)
+	{
+		var t = GetSelectableTables().Where(x => x.Table.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName)).FirstOrDefault();
+		if (t == null)
+		{
+			throw new InvalidProgramException($"Table not found. table:{tableName}");
+		}
+
+		GetQuerySources()
+			.Where(x => x.Source.Equals(t))
+			.GetRootsBySource()
+			.EnsureAny()
+			.ForEach(x =>
+			{
+				x.ColumnNames.ForEach(column => this.Select(x.Alias, column));
+			});
+		return this;
+	}
+
+	public SelectQuery RenameSelect(string columnAliasName, string newAliasName)
+	{
+		var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+		c.SetAlias(newAliasName);
+		return this;
+	}
+
+	public SelectQuery RemoveSelect(string selectableColumnName)
+	{
+		var c = GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(selectableColumnName)).First();
+		SelectClause!.Remove(c);
+		return this;
+	}
+
+	public SelectQuery RemoveSelectAll()
+	{
+		SelectClause = null;
+		return this;
+	}
+
+	/// <summary>
+	/// Searches for the specified column and overrides it.
+	/// </summary>
+	/// <param name="columnAliasName">The name of the column to search for.</param>
+	/// <param name="overrider">The function to modify the column value.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery OverrideSelect(string columnAliasName, Func<IQuerySource, string, string> overrider)
+	{
+		GetQuerySources()
+			.Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
+			.EnsureAny($"column alias:{columnAliasName}")
+			.GetRootsBySource()
+			.ForEach(x =>
+			{
+				var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+				//override
+				si.Value = ValueParser.Parse(overrider(x, si.Value.ToOneLineText()));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Searches for the specified column in the specified table and overrides it.
+	/// </summary>
+	/// <param name="tableName">The name of the table to search in.</param>
+	/// <param name="columnAliasName">The name of the column to search for.</param>
+	/// <param name="overrider">The function to modify the column value.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery OverrideSelect(string tableName, string columnAliasName, Func<IQuerySource, SelectableItem, string> overrider)
+	{
+		GetQuerySources()
+			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
+			.EnsureAny($"table:{tableName}")
+			.Where(x => x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).Any())
+			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column alias:{columnAliasName}")
+			.GetRootsBySource()
+			.EnsureAny()
+			.ForEach(x =>
+			{
+				var si = x.Query.GetSelectableItems().Where(x => x.Alias.IsEqualNoCase(columnAliasName)).First();
+				//override
+				si.Value = ValueParser.Parse(overrider(x, si));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="columnName">The name of the column to search in.</param>
+	/// <param name="adder">The function to create the search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(string columnName, Func<IQuerySource, string> adder)
+	{
+		GetQuerySources()
+			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+			.EnsureAny($"column:{columnName}")
+			.GetRootsBySource()
+			.ForEach(x =>
+			{
+				x.Query.Where(adder(x));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="columnName">The name of the column to search in.</param>
+	/// <param name="adder">The function to create the search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(string columnName, Func<IQuerySource, string, string> adder)
+	{
+		GetQuerySources()
+			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+			.EnsureAny($"column:{columnName}")
+			.GetRootsBySource()
+			.ForEach(x =>
+			{
+				x.Query.Where(adder(x, columnName));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="condition">search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(string condition)
+	{
+		this.Where(condition);
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="adder">The function to create the search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(Func<string> adder)
+	{
+		this.Where(adder());
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="tableName">The name of the table to search in.</param>
+	/// <param name="columnName">The name of the column to search in.</param>
+	/// <param name="adder">The function to create the search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string> adder)
+	{
+		GetQuerySources()
+			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName))
+			.EnsureAny($"table:{tableName}")
+			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
+			.GetRootsBySource()
+			.ForEach(x =>
+			{
+				x.Query.Where(adder(x));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a search condition.
+	/// </summary>
+	/// <param name="tableName">The name of the table to search in.</param>
+	/// <param name="columnName">The name of the column to search in.</param>
+	/// <param name="adder">The function to create the search condition.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddWhere(string tableName, string columnName, Func<IQuerySource, string, string> adder)
+	{
+		GetQuerySources()
+			.Where(x => x.GetTableFullName().IsEqualNoCase(tableName) || x.Alias.IsEqualNoCase(tableName))
+			.EnsureAny($"table:{tableName}")
+			.Where(x => x.ColumnNames.Where(x => x.IsEqualNoCase(columnName)).Any())
+			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{tableName}, column:{columnName}")
+			.GetRootsBySource()
+			.ForEach(x =>
+			{
+				x.Query.Where(adder(x, columnName));
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds an EXISTS clause.
+	/// </summary>
+	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
+	/// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
+	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+	{
+		GetQuerySources()
+			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+			.EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
+			.GetRootsBySource()
+			.ForEach(qs =>
+			{
+				qs.Query.Where(() =>
+				{
+					var sq = new SelectQuery($"select * from {validationTableName} as x");
+					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+					return sq.ToExists();
+				});
+				action?.Invoke(qs);
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds an EXISTS clause.
+	/// </summary>
+	/// <param name="sourceTableName">The name of the table to search in.</param>
+	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
+	/// <param name="validationTableName">The table to use for comparison within the EXISTS clause.</param>
+	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+	{
+		GetQuerySources()
+			.Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName) || x.Alias.IsEqualNoCase(sourceTableName))
+			.EnsureAny($"table:{sourceTableName}")
+			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
+			.GetRootsBySource()
+			.EnsureAny()
+			.ForEach(qs =>
+			{
+				qs.Query.Where(() =>
+				{
+					var sq = new SelectQuery($"select * from {validationTableName} as x");
+					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+					return sq.ToExists();
+				});
+				action?.Invoke(qs);
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a NOT EXISTS clause.
+	/// </summary>
+	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
+	/// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
+	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddNotExists(IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+	{
+		GetQuerySources()
+			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+			.EnsureAny($"columns:{string.Join(",", keyColumnNames)}")
+			.GetRootsBySource()
+			.ForEach(qs =>
+			{
+				qs.Query.Where(() =>
+				{
+					var sq = new SelectQuery($"select * from {validationTableName} as x");
+					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+					return sq.ToNotExists();
+				});
+				action?.Invoke(qs);
+			});
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a NOT EXISTS clause.
+	/// </summary>
+	/// <param name="sourceTableName">The name of the table to search in.</param>
+	/// <param name="keyColumnNames">The columns to use for the search condition.</param>
+	/// <param name="validationTableName">The table to use for comparison within the NOT EXISTS clause.</param>
+	/// <param name="action">An optional function to process the query source, primarily used for adding comments.</param>
+	/// <returns>The modified select query.</returns>
+	public SelectQuery AddNotExists(string sourceTableName, IEnumerable<string> keyColumnNames, string validationTableName, Action<IQuerySource>? action = null)
+	{
+		GetQuerySources()
+			.Where(x => x.GetTableFullName().IsEqualNoCase(sourceTableName))
+			.EnsureAny($"table:{sourceTableName}")
+			.Where(x => keyColumnNames.All(keyColumn => x.ColumnNames.Contains(keyColumn)))
+			.EnsureAny($"The table exists, but there is no corresponding column in the table. table:{sourceTableName}, columns:{string.Join(",", keyColumnNames)}")
+			.GetRootsBySource()
+			.ForEach(qs =>
+			{
+				qs.Query.Where(() =>
+				{
+					var sq = new SelectQuery($"select * from {validationTableName} as x");
+					keyColumnNames.ForEach(keyColumn => sq.Where($"x.{keyColumn} = {qs.Alias}.{keyColumn}"));
+					return sq.ToNotExists();
+				});
+				action?.Invoke(qs);
+			});
+
+		return this;
+	}
+
+	public SelectQuery AddJoin(string joinType, string table, string alias, string condition)
+	{
+		var f = FromClause!;
+		var t = TableParser.Parse(table);
+		var r = f.Join(t.ToSelectable(alias), joinType);
+		r.On(condition);
+		return this;
+	}
+
+	public SelectQuery AddJoin(string joinType, string table, string alias, Func<string> builder)
+	{
+		var f = FromClause!;
+		var t = TableParser.Parse(table);
+		var r = f.Join(t.ToSelectable(alias), joinType);
+		r.On(builder);
+		return this;
+	}
+
+	public SelectQuery AddSelectQuery(string jointType, Func<SelectQuery, SelectQuery> builder)
+	{
+		AddOperatableValue(jointType, builder(this));
+		return this;
+	}
+
+	public SelectQuery ImportCTEQueries(SelectQuery from)
+	{
+		from.GetCommonTables().ForEach(x => this.With(x));
+		return this;
+	}
+
+	public SelectQuery AddParameter(QueryParameter prm)
+	{
+		Parameters.Add(prm);
+		return this;
+	}
+
+	public SelectQuery AddOrder(string columnName, Func<IQuerySource, string, string> adder)
+	{
+		GetQuerySources()
+			.Where(x => x.Query.Equals(this))
+			.ForEach(x =>
+			{
+				x.Query.OrderClause ??= new();
+				x.Query.OrderClause.Add(SortableItemParser.Parse(adder(x, columnName)));
+			});
+
+		return this;
+	}
+
+	public SelectQuery FilterInColumns(IEnumerable<string> columnNames)
+	{
+		if (SelectClause == null) throw new NullReferenceException(nameof(SelectClause));
+		SelectClause.FilterInColumns(columnNames);
+		return this;
+	}
 }

--- a/test/Carbunql.Building.Test/QuerySourceFilterTest.cs
+++ b/test/Carbunql.Building.Test/QuerySourceFilterTest.cs
@@ -1,21 +1,21 @@
-﻿using System.Xml.Linq;
+﻿using Carbunql.Fluent;
 using Xunit.Abstractions;
 
 namespace Carbunql.Building.Test;
 
 public class QuerySourceFilterTest
 {
-    private readonly QueryCommandMonitor Monitor;
+	private readonly QueryCommandMonitor Monitor;
 
-    public QuerySourceFilterTest(ITestOutputHelper output)
-    {
-        Monitor = new QueryCommandMonitor(output);
-    }
+	public QuerySourceFilterTest(ITestOutputHelper output)
+	{
+		Monitor = new QueryCommandMonitor(output);
+	}
 
-    [Fact]
-    public void ShowDataSet()
-    {
-        var sql = @"
+	[Fact]
+	public void ShowDataSet()
+	{
+		var sql = @"
 select 
     s.sale_id
     , s.store_id
@@ -23,23 +23,23 @@ select
 from
     sale as s";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var datasets = query.GetQuerySources().ToList();
-        Monitor.Log(datasets);
+		var datasets = query.GetQuerySources().ToList();
+		Monitor.Log(datasets);
 
-        Assert.Single(datasets);
-    }
+		Assert.Single(datasets);
+	}
 
-    [Fact]
-    public void EqualTest()
-    {
-        var sql = @"
+	[Fact]
+	public void EqualTest()
+	{
+		var sql = @"
 SELECT
     s.sale_id,
     s.store_id,
@@ -48,24 +48,24 @@ FROM
     /* Lv:1, Seq:1, Refs:0-1, Columns:[sale_id, store_id, price] */
     sale AS s";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var column = "sale_id";
-        var value = 1;
+		var column = "sale_id";
+		var value = 1;
 
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
 
-        Monitor.Log(query);
+		Monitor.Log(query);
 
-        var expect = @"SELECT
+		var expect = @"SELECT
     s.sale_id,
     s.store_id,
     s.price
@@ -76,13 +76,13 @@ WHERE
     s.sale_id = 1";
 
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void SubQueryTest()
-    {
-        var sql = @"
+	[Fact]
+	public void SubQueryTest()
+	{
+		var sql = @"
 SELECT
     s2.sale_id,
     s2.store_id,
@@ -99,24 +99,24 @@ FROM
             sale AS s1
     ) AS s2";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var column = "sale_id";
-        var value = 1;
+		var column = "sale_id";
+		var value = 1;
 
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
 
-        Monitor.Log(query);
+		Monitor.Log(query);
 
-        var expect = @"SELECT
+		var expect = @"SELECT
     s2.sale_id,
     s2.store_id,
     s2.price
@@ -134,13 +134,13 @@ FROM
             s1.sale_id = 1
     ) AS s2";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void InnerJoinTest()
-    {
-        var sql = @"
+	[Fact]
+	public void InnerJoinTest()
+	{
+		var sql = @"
 SELECT
     s.sale_id,
     s.store_id,
@@ -152,25 +152,25 @@ FROM
     /* Lv:1, Seq:2, Refs:0-2, Columns:[store_id] */
     store AS st ON s.store_id = st.store_id";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var column = "store_id";
-        var value = 1;
+		var column = "store_id";
+		var value = 1;
 
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
 
-        Monitor.Log(query);
+		Monitor.Log(query);
 
-        //Other query sources within the same query may also be included in the search.
-        var expect = @"SELECT
+		//Other query sources within the same query may also be included in the search.
+		var expect = @"SELECT
     s.sale_id,
     s.store_id,
     s.price
@@ -184,13 +184,13 @@ WHERE
     s.store_id = 1
     AND st.store_id = 1";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void InnerJoinTest_GetRootDataSetsByBranchGetRootDataSetsByQuery()
-    {
-        var sql = @"
+	[Fact]
+	public void InnerJoinTest_GetRootDataSetsByBranchGetRootDataSetsByQuery()
+	{
+		var sql = @"
 SELECT
     s.sale_id,
     s.store_id,
@@ -203,30 +203,30 @@ FROM
     /* Lv:1, Seq:2, Refs:0-2, Columns:[store_name, store_id] */
     store AS st ON s.store_id = st.store_id";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var datasets = query.GetQuerySources().ToList();
-        Monitor.Log(datasets);
+		var datasets = query.GetQuerySources().ToList();
+		Monitor.Log(datasets);
 
-        var column = "store_id";
-        var value = 1;
+		var column = "store_id";
+		var value = 1;
 
-        //If you want to apply a single search condition to a query, write it like this.
-        //However, when considering outer joins, it may be best to refrain from modifying it to this extent.
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .GetRootsByQuery()
-            .ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
+		//If you want to apply a single search condition to a query, write it like this.
+		//However, when considering outer joins, it may be best to refrain from modifying it to this extent.
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.GetRootsByQuery()
+			.ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
 
-        Monitor.Log(query);
+		Monitor.Log(query);
 
-        var expect = @"SELECT
+		var expect = @"SELECT
     s.sale_id,
     s.store_id,
     st.store_name,
@@ -240,13 +240,13 @@ FROM
 WHERE
     s.store_id = 1";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void CTETest()
-    {
-        var sql = @"
+	[Fact]
+	public void CTETest()
+	{
+		var sql = @"
 WITH
     sx AS (
         SELECT
@@ -265,24 +265,24 @@ FROM
     /* Lv:1, Seq:1, Refs:0-1, Columns:[sale_id, store_id, price] */
     sx AS s2";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Lv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var column = "store_id";
-        var value = 1;
+		var column = "store_id";
+		var value = 1;
 
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.ForEach(ds => ds.Query.Where(ds.Alias, column).Equal(value));
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"WITH
+		var expect = @"WITH
     sx AS (
         SELECT
             s1.sale_id,
@@ -302,13 +302,13 @@ FROM
     /* Lv:1, Columns:[sale_id, store_id, price] */
     sx AS s2";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void PracticalTest()
-    {
-        var sql = @"WITH
+	[Fact]
+	public void PracticalTest()
+	{
+		var sql = @"WITH
     monthly_sales AS (
         SELECT
             customer_id,
@@ -339,29 +339,29 @@ ORDER BY
     c.customer_id,
     ms.sale_month";
 
-        var query = new SelectQuery(sql);
-        query.GetQuerySources().ForEach(x =>
-        {
-            x.AddSourceComment($"Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
-            x.ToTreePaths().ForEach(path => x.AddSourceComment($"Path:{string.Join("-", path)}"));
-        });
-        Monitor.Log(query, exportTokens: false);
+		var query = new SelectQuery(sql);
+		query.GetQuerySources().ForEach(x =>
+		{
+			x.AddSourceComment($"Index:{x.Index}, MaxLv:{x.MaxLevel}, Columns:[{string.Join(", ", x.ColumnNames)}]");
+			x.ToTreePaths().ForEach(path => x.AddSourceComment($"Path:{string.Join("-", path)}"));
+		});
+		Monitor.Log(query, exportTokens: false);
 
-        var column = "customer_id";
-        var value = 1;
+		var column = "customer_id";
+		var value = 1;
 
-        query.GetQuerySources()
-            .Where(ds => ds.ColumnNames.Contains(column))
-            .GetRootsBySource()
-            .ForEach(ds =>
-            {
-                ds.AddSourceComment("inject filter");
-                ds.Query.Where(ds.Alias, column).Equal(value);
-            });
+		query.GetQuerySources()
+			.Where(ds => ds.ColumnNames.Contains(column))
+			.GetRootsBySource()
+			.ForEach(ds =>
+			{
+				ds.AddSourceComment("inject filter");
+				ds.Query.Where(ds.Alias, column).Equal(value);
+			});
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"WITH
+		var expect = @"WITH
     monthly_sales AS (
         SELECT
             customer_id,
@@ -398,13 +398,13 @@ ORDER BY
     c.customer_id,
     ms.sale_month";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void NotExistsInsertTest()
-    {
-        var sql = """
+	[Fact]
+	public void NotExistsInsertTest()
+	{
+		var sql = """
     select
         s.sale_id
         , s.store_id
@@ -415,18 +415,18 @@ ORDER BY
         sales as s
     """;
 
-        var lower_limit = new DateTime(2024, 7, 20);
+		var lower_limit = new DateTime(2024, 7, 20);
 
-        var query = new SelectQuery(sql)
-            .OverrideSelect("journal_date", (source, item) => $"greatest({item}, {source.Query.AddParameter(":lower_limit", lower_limit)})")
-            .AddNotExists(["sale_id"], "sale_journals")
-            .AddWhere("request_timestamp", (source) => $"{source.Alias}.request_timestamp >= :lower_limit")
-            .ToCTEQuery("final", "f")
-            .ToInsertQuery("sale_journals");
+		var query = new SelectQuery(sql)
+			.OverrideSelect("journal_date", (source, item) => $"greatest({item}, {source.Query.AddParameter(":lower_limit", lower_limit)})")
+			.AddNotExists(["sale_id"], "sale_journals")
+			.AddWhere("request_timestamp", (source) => $"{source.Alias}.request_timestamp >= :lower_limit")
+			.ToCTEQuery("final", "f")
+			.ToInsertQuery("sale_journals");
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :lower_limit = '2024/07/20 0:00:00'
 */
 INSERT INTO
@@ -461,13 +461,13 @@ SELECT
 FROM
     final AS f";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void ImmutableInsertTest()
-    {
-        var sql = """
+	[Fact]
+	public void ImmutableInsertTest()
+	{
+		var sql = """
     select
         s.sale_id
         , s.store_id
@@ -478,10 +478,10 @@ FROM
         sales as s
     """;
 
-        var d = new DateTime(2024, 7, 1);
-        var query = new SelectQuery()
-            // Define expected values (current values) as a CTE named 'expect'
-            .AddCTEQuery("""
+		var d = new DateTime(2024, 7, 1);
+		var query = new SelectQuery()
+			// Define expected values (current values) as a CTE named 'expect'
+			.AddCTEQuery("""
         select distinct on(sale_id) 
             sale_id
             , store_id
@@ -495,40 +495,40 @@ FROM
             sale_id
             , sale_journal_id desc
     """, "expect")
-            // Define the correct values as a CTE named 'actual'
-            .AddCTEQuery(sql, "actual")
-            // Compare the expected and correct values, and format the differences with red/black formatting
-            .AddFrom("expect", "exp")
-            .AddJoin("inner join", "actual", "act", "exp.sale_id = act.sale_id")
-            .AddWhere("exp.journal_price <> act.journal_price")
-            .OverrideSelect("journal_date", (source, item) => $"greatest({item}, {source.Query.AddParameter(":mod_date", d)})")
-            .AddSelectAll("exp")
-            .RemoveSelect("journal_price")
-            .AddSelect("exp.journal_price * -1", "reverse_price")
-            .AddSelect("act.journal_price * +1", "collect_price")
-            // Define the query result with red/black formatting as a CTE named 'diff' and select it
-            .ToCTEQuery("diff", "r")
-            // Since we want to process red entries, the collect_price value is unnecessary; use reverse_price as the journal value
-            .RemoveSelect("collect_price")
-            .RenameSelect("reverse_price", "journal_price")
-            // To process black entries, generate a UNION ALL query
-            .AddSelectQuery("union all", owner =>
-            {
-                return new SelectQuery()
-                    // Since we want to use the CTE 'diff', import the CTE information
-                    .ImportCTEQueries(owner)
-                    // Define the black entry selection query, similar to the red entry
-                    .AddFrom("diff", "c")
-                    .AddSelectAll("c")
-                    .RemoveSelect("reverse_price")
-                    .RenameSelect("collect_price", "journal_price");
-            })
-            // Convert to an insert query
-            .ToInsertQuery("sale_journals");
+			// Define the correct values as a CTE named 'actual'
+			.AddCTEQuery(sql, "actual")
+			// Compare the expected and correct values, and format the differences with red/black formatting
+			.AddFrom("expect", "exp")
+			.AddJoin("inner join", "actual", "act", "exp.sale_id = act.sale_id")
+			.AddWhere("exp.journal_price <> act.journal_price")
+			.OverrideSelect("journal_date", (source, item) => $"greatest({item}, {source.Query.AddParameter(":mod_date", d)})")
+			.AddSelectAll("exp")
+			.RemoveSelect("journal_price")
+			.AddSelect("exp.journal_price * -1", "reverse_price")
+			.AddSelect("act.journal_price * +1", "collect_price")
+			// Define the query result with red/black formatting as a CTE named 'diff' and select it
+			.ToCTEQuery("diff", "r")
+			// Since we want to process red entries, the collect_price value is unnecessary; use reverse_price as the journal value
+			.RemoveSelect("collect_price")
+			.RenameSelect("reverse_price", "journal_price")
+			// To process black entries, generate a UNION ALL query
+			.AddSelectQuery("union all", owner =>
+			{
+				return new SelectQuery()
+					// Since we want to use the CTE 'diff', import the CTE information
+					.ImportCTEQueries(owner)
+					// Define the black entry selection query, similar to the red entry
+					.AddFrom("diff", "c")
+					.AddSelectAll("c")
+					.RemoveSelect("reverse_price")
+					.RenameSelect("collect_price", "journal_price");
+			})
+			// Convert to an insert query
+			.ToInsertQuery("sale_journals");
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :mod_date = '2024/07/01 0:00:00'
 */
 INSERT INTO
@@ -587,10 +587,10 @@ SELECT
 FROM
     diff AS c";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    private string SelectCustomers => """
+	private string SelectCustomers => """
     SELECT
         c.customer_id,
         c.first_name,
@@ -609,47 +609,47 @@ FROM
     OFFSET :page_index;
     """;
 
-    [Fact]
-    public void DynamicConditionTest_City_BirthDay()
-    {
-        var pageIndex = 0;
+	[Fact]
+	public void DynamicConditionTest_City_BirthDay()
+	{
+		var pageIndex = 0;
 
-        var firstName = "Ichiro";
-        var lastName = "Tanaka";
-        var city = "Tokyo";
-        DateTime? birthday = new DateTime(1980, 5, 15);
+		var firstName = "Ichiro";
+		var lastName = "Tanaka";
+		var city = "Tokyo";
+		DateTime? birthday = new DateTime(1980, 5, 15);
 
-        var query = new SelectQuery(SelectCustomers)
-            .AddParameter(new QueryParameter(":page_index", pageIndex));
+		var query = new SelectQuery(SelectCustomers)
+			.AddParameter(new QueryParameter(":page_index", pageIndex));
 
-        if (!string.IsNullOrEmpty(firstName))
-        {
-            var pname = ":first_name";
-            query.AddParameter(new QueryParameter(pname, firstName))
-                        .AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(lastName))
-        {
-            var pname = ":last_name";
-            query.AddParameter(new QueryParameter(pname, lastName))
-                            .AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(city))
-        {
-            var pname = ":city";
-            query.AddParameter(new QueryParameter(pname, lastName))
-                .AddWhere("city", x => $"{x.Alias}.city = {pname}");
-        }
-        if (birthday != null)
-        {
-            var pname = ":birthday";
-            query.AddParameter(new QueryParameter(pname, birthday.Value))
-                .AddWhere("birthday", x => $"{x.Alias}.birthday = {pname}");
-        }
+		if (!string.IsNullOrEmpty(firstName))
+		{
+			var pname = ":first_name";
+			query.AddParameter(new QueryParameter(pname, firstName))
+						.AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(lastName))
+		{
+			var pname = ":last_name";
+			query.AddParameter(new QueryParameter(pname, lastName))
+							.AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(city))
+		{
+			var pname = ":city";
+			query.AddParameter(new QueryParameter(pname, lastName))
+				.AddWhere("city", x => $"{x.Alias}.city = {pname}");
+		}
+		if (birthday != null)
+		{
+			var pname = ":birthday";
+			query.AddParameter(new QueryParameter(pname, birthday.Value))
+				.AddWhere("birthday", x => $"{x.Alias}.birthday = {pname}");
+		}
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :page_index = 0
   :first_name = 'Ichiro'
   :last_name = 'Tanaka'
@@ -678,50 +678,50 @@ ORDER BY
 LIMIT
     20 OFFSET :page_index";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void DynamicConditionTest_SaleId_Exists()
-    {
-        var pageIndex = 0;
+	[Fact]
+	public void DynamicConditionTest_SaleId_Exists()
+	{
+		var pageIndex = 0;
 
-        var firstName = "Ichiro";
-        var lastName = "Tanaka";
-        long? customerId = 1234567890;
-        long? saleId = 9999999;
+		var firstName = "Ichiro";
+		var lastName = "Tanaka";
+		long? customerId = 1234567890;
+		long? saleId = 9999999;
 
-        var query = new SelectQuery(SelectCustomers)
-            .AddParameter(new QueryParameter(":page_index", pageIndex));
+		var query = new SelectQuery(SelectCustomers)
+			.AddParameter(new QueryParameter(":page_index", pageIndex));
 
-        if (!string.IsNullOrEmpty(firstName))
-        {
-            var pname = ":first_name";
-            query.AddParameter(new QueryParameter(pname, firstName))
-                .AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(lastName))
-        {
-            var pname = ":last_name";
-            query.AddParameter(new QueryParameter(pname, lastName))
-                            .AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
-        }
-        if (customerId != null)
-        {
-            var pname = ":customer_id";
-            query.AddParameter(new QueryParameter(pname, customerId.Value))
-                .AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
-        }
-        if (saleId != null)
-        {
-            var pname = ":sale_id";
-            query.AddParameter(new QueryParameter(pname, saleId.Value))
-                .AddExists(["customer_id"], "sales");
-        }
+		if (!string.IsNullOrEmpty(firstName))
+		{
+			var pname = ":first_name";
+			query.AddParameter(new QueryParameter(pname, firstName))
+				.AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(lastName))
+		{
+			var pname = ":last_name";
+			query.AddParameter(new QueryParameter(pname, lastName))
+							.AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
+		}
+		if (customerId != null)
+		{
+			var pname = ":customer_id";
+			query.AddParameter(new QueryParameter(pname, customerId.Value))
+				.AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
+		}
+		if (saleId != null)
+		{
+			var pname = ":sale_id";
+			query.AddParameter(new QueryParameter(pname, saleId.Value))
+				.AddExists(["customer_id"], "sales");
+		}
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :page_index = 0
   :first_name = 'Ichiro'
   :last_name = 'Tanaka'
@@ -757,51 +757,51 @@ ORDER BY
 LIMIT
     20 OFFSET :page_index";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void DynamicConditionTest_SaleId_Join()
-    {
-        var pageIndex = 0;
+	[Fact]
+	public void DynamicConditionTest_SaleId_Join()
+	{
+		var pageIndex = 0;
 
-        var firstName = "Ichiro";
-        var lastName = "Tanaka";
-        long? customerId = 1234567890;
-        long? saleId = 9999999;
+		var firstName = "Ichiro";
+		var lastName = "Tanaka";
+		long? customerId = 1234567890;
+		long? saleId = 9999999;
 
-        var query = new SelectQuery(SelectCustomers)
-            .AddParameter(new QueryParameter(":page_index", pageIndex));
+		var query = new SelectQuery(SelectCustomers)
+			.AddParameter(new QueryParameter(":page_index", pageIndex));
 
-        if (!string.IsNullOrEmpty(firstName))
-        {
-            var pname = ":first_name";
-            query.AddParameter(new QueryParameter(pname, firstName))
-                .AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(lastName))
-        {
-            var pname = ":last_name";
-            query.AddParameter(new QueryParameter(pname, lastName))
-                            .AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
-        }
-        if (customerId != null)
-        {
-            var pname = ":customer_id";
-            query.AddParameter(new QueryParameter(pname, customerId.Value))
-                .AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
-        }
-        if (saleId != null)
-        {
-            var pname = ":sale_id";
-            query.AddParameter(new QueryParameter(pname, saleId.Value))
-                .AddJoin("inner join", "sales", "s", "c.customer_id = s.customer_id")
-                .AddWhere($"s.sale_id = {pname}");
-        }
+		if (!string.IsNullOrEmpty(firstName))
+		{
+			var pname = ":first_name";
+			query.AddParameter(new QueryParameter(pname, firstName))
+				.AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(lastName))
+		{
+			var pname = ":last_name";
+			query.AddParameter(new QueryParameter(pname, lastName))
+							.AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
+		}
+		if (customerId != null)
+		{
+			var pname = ":customer_id";
+			query.AddParameter(new QueryParameter(pname, customerId.Value))
+				.AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
+		}
+		if (saleId != null)
+		{
+			var pname = ":sale_id";
+			query.AddParameter(new QueryParameter(pname, saleId.Value))
+				.AddJoin("inner join", "sales", "s", "c.customer_id = s.customer_id")
+				.AddWhere($"s.sale_id = {pname}");
+		}
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :page_index = 0
   :first_name = 'Ichiro'
   :last_name = 'Tanaka'
@@ -831,52 +831,52 @@ ORDER BY
 LIMIT
     20 OFFSET :page_index";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void DynamicConditionTest_StoreName_Exists()
-    {
-        var pageIndex = 0;
+	[Fact]
+	public void DynamicConditionTest_StoreName_Exists()
+	{
+		var pageIndex = 0;
 
-        var firstName = "Ichiro";
-        var lastName = "Tanaka";
-        long? customerId = 1234567890;
-        var storeName = "Osaka";
+		var firstName = "Ichiro";
+		var lastName = "Tanaka";
+		long? customerId = 1234567890;
+		var storeName = "Osaka";
 
-        var query = new SelectQuery(SelectCustomers)
-            .AddParameter(new QueryParameter(":page_index", pageIndex));
+		var query = new SelectQuery(SelectCustomers)
+			.AddParameter(new QueryParameter(":page_index", pageIndex));
 
-        if (!string.IsNullOrEmpty(storeName))
-        {
-            var pname = ":store_name";
-            query.AddCTEQuery("select s.sale_id, s.customer_id, st.store_name from sales s inner join stores st on s.store_id = st.store_id", "target_sales")
-                .AddExists(["customer_id"], "target_sales")
-                .AddParameter(new QueryParameter(pname, storeName))
-                .AddWhere("store_name", x => $"{x.Alias}.store_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(firstName))
-        {
-            var pname = ":first_name";
-            query.AddParameter(new QueryParameter(pname, firstName))
-                .AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
-        }
-        if (!string.IsNullOrEmpty(lastName))
-        {
-            var pname = ":last_name";
-            query.AddParameter(new QueryParameter(pname, lastName))
-                .AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
-        }
-        if (customerId != null)
-        {
-            var pname = ":customer_id";
-            query.AddParameter(new QueryParameter(pname, customerId.Value))
-                .AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
-        }
+		if (!string.IsNullOrEmpty(storeName))
+		{
+			var pname = ":store_name";
+			query.AddCTEQuery("select s.sale_id, s.customer_id, st.store_name from sales s inner join stores st on s.store_id = st.store_id", "target_sales")
+				.AddExists(["customer_id"], "target_sales")
+				.AddParameter(new QueryParameter(pname, storeName))
+				.AddWhere("store_name", x => $"{x.Alias}.store_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(firstName))
+		{
+			var pname = ":first_name";
+			query.AddParameter(new QueryParameter(pname, firstName))
+				.AddWhere("first_name", x => $"{x.Alias}.first_name = {pname}");
+		}
+		if (!string.IsNullOrEmpty(lastName))
+		{
+			var pname = ":last_name";
+			query.AddParameter(new QueryParameter(pname, lastName))
+				.AddWhere("last_name", x => $"{x.Alias}.last_name = {pname}");
+		}
+		if (customerId != null)
+		{
+			var pname = ":customer_id";
+			query.AddParameter(new QueryParameter(pname, customerId.Value))
+				.AddWhere("customer_id", x => $"{x.Alias}.customer_id = {pname}");
+		}
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :page_index = 0
   :store_name = 'Osaka'
   :first_name = 'Ichiro'
@@ -925,61 +925,61 @@ ORDER BY
 LIMIT
     20 OFFSET :page_index";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 
-    [Fact]
-    public void DynamicConditionTest()
-    {
-        var pageIndex = 0;
+	[Fact]
+	public void DynamicConditionTest()
+	{
+		var pageIndex = 0;
 
-        var first_name = "Ichiro";
-        var last_name = "Tanaka";
-        long? customer_id = 1234567890;
-        long? sale_id = 9999999;
-        var store_name = "Osaka";
-        var city = "Tokyo";
-        DateTime? birthday = new DateTime(1980, 5, 15);
+		var first_name = "Ichiro";
+		var last_name = "Tanaka";
+		long? customer_id = 1234567890;
+		long? sale_id = 9999999;
+		var store_name = "Osaka";
+		var city = "Tokyo";
+		DateTime? birthday = new DateTime(1980, 5, 15);
 
-        var query = new SelectQuery(SelectCustomers)
-            .AddParameter(new QueryParameter(":page_index", pageIndex));
+		var query = new SelectQuery(SelectCustomers)
+			.AddParameter(new QueryParameter(":page_index", pageIndex));
 
-        // add CTE
-        if (!string.IsNullOrEmpty(store_name) || sale_id != null)
-        {
-            if (!string.IsNullOrEmpty(store_name))
-            {
-                query.AddCTEQuery("select s.sale_id, s.customer_id, st.store_name from sales s inner join stores st on s.store_id = st.store_id", "target_sales")
-                    .AddExists(["customer_id"], "target_sales");
-            }
-            else
-            {
-                query.AddCTEQuery("select s.sale_id, s.customer_id from sales s", "target_sales")
-                    .AddExists(["customer_id"], "target_sales");
-            }
-        }
+		// add CTE
+		if (!string.IsNullOrEmpty(store_name) || sale_id != null)
+		{
+			if (!string.IsNullOrEmpty(store_name))
+			{
+				query.AddCTEQuery("select s.sale_id, s.customer_id, st.store_name from sales s inner join stores st on s.store_id = st.store_id", "target_sales")
+					.AddExists(["customer_id"], "target_sales");
+			}
+			else
+			{
+				query.AddCTEQuery("select s.sale_id, s.customer_id from sales s", "target_sales")
+					.AddExists(["customer_id"], "target_sales");
+			}
+		}
 
-        //list
-        var items = new Dictionary<string, object>();
-        if (sale_id.HasValue) items.Add(nameof(sale_id), sale_id.Value);
-        if (!string.IsNullOrEmpty(store_name)) items.Add(nameof(store_name), store_name);
-        if (!string.IsNullOrEmpty(first_name)) items.Add(nameof(first_name), first_name);
-        if (!string.IsNullOrEmpty(last_name)) items.Add(nameof(last_name), last_name);
-        if (!string.IsNullOrEmpty(city)) items.Add(nameof(city), city);
-        if (customer_id.HasValue) items.Add(nameof(customer_id), customer_id.Value);
-        if (birthday.HasValue) items.Add(nameof(birthday), birthday.Value);
+		//list
+		var items = new Dictionary<string, object>();
+		if (sale_id.HasValue) items.Add(nameof(sale_id), sale_id.Value);
+		if (!string.IsNullOrEmpty(store_name)) items.Add(nameof(store_name), store_name);
+		if (!string.IsNullOrEmpty(first_name)) items.Add(nameof(first_name), first_name);
+		if (!string.IsNullOrEmpty(last_name)) items.Add(nameof(last_name), last_name);
+		if (!string.IsNullOrEmpty(city)) items.Add(nameof(city), city);
+		if (customer_id.HasValue) items.Add(nameof(customer_id), customer_id.Value);
+		if (birthday.HasValue) items.Add(nameof(birthday), birthday.Value);
 
-        foreach (var item in items)
-        {
-            var column = item.Key;
-            var pname = $":{column}";
-            query.AddParameter(new QueryParameter(pname, item.Value))
-                .AddWhere(column, x => $"{x.Alias}.{column} = {pname}");
-        }
+		foreach (var item in items)
+		{
+			var column = item.Key;
+			var pname = $":{column}";
+			query.AddParameter(new QueryParameter(pname, item.Value))
+				.AddWhere(column, x => $"{x.Alias}.{column} = {pname}");
+		}
 
-        Monitor.Log(query, exportTokens: false);
+		Monitor.Log(query, exportTokens: false);
 
-        var expect = @"/*
+		var expect = @"/*
   :page_index = 0
   :sale_id = 9999999
   :store_name = 'Osaka'
@@ -1034,6 +1034,82 @@ ORDER BY
 LIMIT
     20 OFFSET :page_index";
 
-        Assert.Equal(expect, query.ToText(), true, true, true);
-    }
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
+
+
+	[Fact]
+	public void ColumnAliasTest()
+	{
+		var sql = """
+            select
+                *
+            from
+                (
+                    select 
+                        s.id as sale_id
+                    from
+                        sale as s
+                ) d
+            """;
+
+		var query = new SelectQuery(sql)
+			.Equal("sale_id", 1);
+
+		Monitor.Log(query, exportTokens: false);
+
+		var expect = """
+            SELECT
+                *
+            FROM
+                (
+                    SELECT
+                        s.id AS sale_id
+                    FROM
+                        sale AS s
+                ) AS d
+            WHERE
+                d.sale_id = 1
+            """;
+
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
+
+
+	[Fact]
+	public void ColumnAliasTest_Table()
+	{
+		var sql = """
+            select
+                *
+            from
+                (
+                    select 
+                        s.id as sale_id
+                    from
+                        sale as s
+                ) d
+            """;
+
+		var query = new SelectQuery(sql)
+			.Equal("d", "sale_id", 1);
+
+		Monitor.Log(query, exportTokens: false);
+
+		var expect = """
+            SELECT
+                *
+            FROM
+                (
+                    SELECT
+                        s.id AS sale_id
+                    FROM
+                        sale AS s
+                ) AS d
+            WHERE
+                d.sale_id = 1
+            """;
+
+		Assert.Equal(expect, query.ToText(), true, true, true);
+	}
 }


### PR DESCRIPTION
Fixed a bug that caused the filter function to not work if a column had an alias. 
Improved the error message when the filter target cannot be found. The name of the table or column that was not found is now displayed in the error message. 
The reference to Dapper has been removed from the library itself (it was not necessary).