### PR TITLE
Add support for ESCAPE keyword in LIKE clause parsing

### DIFF
--- a/src/Carbunql/Analysis/Parser/LikeClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/LikeClauseParser.cs
@@ -1,4 +1,5 @@
 ﻿using Carbunql.Clauses;
+using Carbunql.Extensions;
 using Carbunql.Values;
 
 namespace Carbunql.Analysis.Parser;
@@ -32,6 +33,16 @@ public static class LikeClauseParser
         r.Read("like");
 
         var argument = ValueParser.ParseCore(r);
-        return new LikeClause(value, argument, isNegative);
+
+        if (r.Peek().IsEqualNoCase("escape"))
+        {
+            r.Read("escape");
+            var escape = r.Read();
+            return new LikeClause(value, argument, isNegative, escape);
+        }
+        else
+        {
+            return new LikeClause(value, argument, isNegative);
+        }
     }
 }

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql is an advanced Raw SQL editing library.</Description>
-		<Version>0.8.11</Version>
+		<Version>0.8.12</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/Values/LikeClause.cs
+++ b/src/Carbunql/Values/LikeClause.cs
@@ -14,11 +14,12 @@ public class LikeClause : ValueBase
     /// <param name="value">The value to compare.</param>
     /// <param name="argument">The argument to compare against.</param>
     /// <param name="isNegative">Indicates whether the comparison is negated.</param>
-    public LikeClause(ValueBase value, ValueBase argument, bool isNegative = false)
+    public LikeClause(ValueBase value, ValueBase argument, bool isNegative = false, string escape = "")
     {
         Value = value;
         Argument = argument;
         IsNegative = isNegative;
+        Escape = escape;
     }
 
     /// <summary>
@@ -35,6 +36,12 @@ public class LikeClause : ValueBase
     /// Gets or sets a value indicating whether the comparison is negated.
     /// </summary>
     public bool IsNegative { get; set; }
+
+    /// <summary>
+    /// Gets or sets the escape character used in the LIKE clause.
+    /// This character allows special symbols (such as underscores or percent signs) to be treated as literal characters.
+    /// </summary>
+    public string Escape { get; set; }
 
     /// <inheritdoc/>
     protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
@@ -58,6 +65,12 @@ public class LikeClause : ValueBase
 
         yield return Token.Reserved(this, parent, "like");
         foreach (var item in Argument.GetTokens(parent)) yield return item;
+
+        if (!string.IsNullOrEmpty(Escape))
+        {
+            yield return Token.Reserved(this, parent, "escape");
+            yield return new Token(this, parent, Escape);
+        }
     }
 
     /// <inheritdoc/>

--- a/test/Carbunql.Analysis.Test/ValueParseTest.cs
+++ b/test/Carbunql.Analysis.Test/ValueParseTest.cs
@@ -526,6 +526,17 @@ public class ValueParserTest
     }
 
     [Fact]
+    public void LikeEscape()
+    {
+        var text = "a.name LIKE 'x%3%' escape 'x'";
+        var v = ValueParser.Parse(text);
+        Monitor.Log(v);
+
+        var lst = v.GetTokens().ToList();
+        Assert.Equal(7, lst.Count);
+    }
+
+    [Fact]
     public void Bracket()
     {
         var text = "(1)";


### PR DESCRIPTION
- Implemented handling of the ESCAPE keyword in the LIKE clause.
- Added logic to recognize and process escape characters in pattern matching.
- Updated test cases to validate LIKE clauses with custom escape characters.