### PR TITLE
Fix: Adjusted column alias handling in Select method to avoid empty alias.

### DIFF
--- a/src/Carbunql/Fluent/SelectQuerySelectExtensions.cs
+++ b/src/Carbunql/Fluent/SelectQuerySelectExtensions.cs
@@ -47,9 +47,18 @@ public static class SelectQuerySelectExtensions
         return query;
     }
 
+    /// <summary>
+    /// Adds a column selection to the query with an optional alias.
+    /// If the provided alias is null or empty, the column name will be used as the alias.
+    /// </summary>
+    /// <param name="query">The current SelectQuery object.</param>
+    /// <param name="tableAlias">The alias of the table that contains the column.</param>
+    /// <param name="column">The name of the column to select.</param>
+    /// <param name="columnAlias">Optional alias for the column. If not provided or empty, the column name will be used.</param>
+    /// <returns>The updated SelectQuery object.</returns>
     public static SelectQuery Select(this SelectQuery query, string tableAlias, string column, string columnAlias = "")
     {
-        query.AddSelect($"{tableAlias}.{column}", columnAlias);
+        query.AddSelect($"{tableAlias}.{column}", string.IsNullOrEmpty(columnAlias) ? column : columnAlias);
         return query;
     }
 

--- a/src/Carbunql/IQuerySource.cs
+++ b/src/Carbunql/IQuerySource.cs
@@ -1,5 +1,6 @@
 ﻿using Carbunql.Building;
 using Carbunql.Clauses;
+using Carbunql.Extensions;
 using Carbunql.Tables;
 
 namespace Carbunql;


### PR DESCRIPTION
### Summary
This PR improves the `Select` method by adjusting how the column alias is handled. Previously, an empty alias string could be passed, which would lead to inconsistent SQL queries. With this change, if the `columnAlias` is empty, the column name itself is used as the alias, ensuring more predictable behavior.

### Changes
- Modified the `Select` method to check if `columnAlias` is empty or null.
- If `columnAlias` is empty, the column name is used as the alias instead of an empty string.

### Why
This update prevents issues where empty column aliases could cause SQL query inconsistencies.
