### PR TITLE
Add support for parsing UPDATE queries

### DIFF
--- a/demo/CarbunqlWeb/Pages/Format.razor
+++ b/demo/CarbunqlWeb/Pages/Format.razor
@@ -8,7 +8,7 @@
 
 <RadzenText TextStyle="TextStyle.H4">Format</RadzenText>
 
-<RadzenText>SQL can be formatted.(select, values, insert, create table, create index, alter table)</RadzenText>
+<RadzenText>SQL can be formatted.(select, values, insert, update, create table, create index, alter table)</RadzenText>
 
 <RadzenTabs TabPosition=TabPosition.Top RenderMode="TabRenderMode.Client" >
     <Tabs>

--- a/src/Carbunql/Analysis/Parser/FromClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/FromClauseParser.cs
@@ -26,6 +26,8 @@ public static class FromClauseParser
     /// <returns>The parsed FROM clause.</returns>
     public static FromClause Parse(ITokenReader r)
     {
+        r.ReadOrDefault("from");
+
         var relationtokens = ReservedText.GetRelationTexts();
 
         var root = SelectableTableParser.Parse(r);

--- a/src/Carbunql/Analysis/Parser/SelectableTableParser.cs
+++ b/src/Carbunql/Analysis/Parser/SelectableTableParser.cs
@@ -45,6 +45,13 @@ public static class SelectableTableParser
         else
         {
             r.ReadOrDefault("as");
+
+            var next = r.Peek();
+            if (next.IsEqualNoCase(["from", "set"]))
+            {
+                return new SelectableTable(v, v.GetDefaultName());
+            }
+
             var alias = r.Read();
 
             if (TryParseColumnAliases(r, out var columnAliases))

--- a/src/Carbunql/Analysis/Parser/SetClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/SetClauseParser.cs
@@ -1,0 +1,31 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class SetClauseParser
+{
+
+    public static SetClause Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        return Parse(r);
+    }
+
+    public static SetClause Parse(ITokenReader r)
+    {
+        r.Read("set");
+
+        var s = new SetClause
+        {
+            ValueParser.Parse(r)
+        };
+
+        while (r.Peek() == ",")
+        {
+            r.Read(",");
+            s.Add(ValueParser.Parse(r));
+        }
+
+        return s;
+    }
+}

--- a/src/Carbunql/Analysis/Parser/UpdateClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/UpdateClauseParser.cs
@@ -1,0 +1,19 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class UpdateClauseParser
+{
+
+    public static UpdateClause Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        return Parse(r);
+    }
+
+    public static UpdateClause Parse(ITokenReader r)
+    {
+        r.Read("update");
+        return new UpdateClause(SelectableTableParser.Parse(r));
+    }
+}

--- a/src/Carbunql/Analysis/QueryCommandableParser.cs
+++ b/src/Carbunql/Analysis/QueryCommandableParser.cs
@@ -64,6 +64,12 @@ public static class QueryCommandableParser
                 }
                 return iq;
             }
+            else if (token.IsEqualNoCase("update"))
+            {
+                var uq = UpdateQueryParser.Parse(r);
+                uq.WithClause = clause;
+                return uq;
+            }
 
             throw new NotSupportedException($"Unsupported query command: '{token}'");
         }
@@ -73,6 +79,7 @@ public static class QueryCommandableParser
             if (token.IsEqualNoCase("values")) return ValuesQueryParser.Parse(r);
 
             if (token.IsEqualNoCase("insert into")) return InsertQueryParser.Parse(r);
+            if (token.IsEqualNoCase("update")) return UpdateQueryParser.Parse(r);
 
             if (token.IsEqualNoCase("create table")) return CreateTableQueryParser.Parse(r);
             if (token.IsEqualNoCase("create index")) return CreateIndexQueryParser.Parse(r);

--- a/src/Carbunql/Analysis/UpdateQueryParser.cs
+++ b/src/Carbunql/Analysis/UpdateQueryParser.cs
@@ -1,0 +1,69 @@
+﻿using Carbunql.Analysis.Parser;
+using Carbunql.Clauses;
+using Carbunql.Extensions;
+
+namespace Carbunql.Analysis;
+
+/// <summary>
+/// Provides methods for parsing ALTER TABLE queries from SQL token streams.
+/// </summary>
+public static class UpdateQueryParser
+{
+    /// <summary>
+    /// Parses an ALTER TABLE query from SQL text.
+    /// </summary>
+    /// <param name="text">The SQL text to parse.</param>
+    /// <returns>The parsed ALTER TABLE query.</returns>
+    public static UpdateQuery Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        var query = Parse(r);
+
+        // If there are unparsed tokens remaining, it indicates an issue with parsing.
+        if (!r.Peek().IsEndToken())
+        {
+            throw new NotSupportedException($"Parsing terminated despite the presence of unparsed tokens. (Token: '{r.Peek()}')");
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Parses an ALTER TABLE query from a token reader.
+    /// </summary>
+    /// <param name="r">The token reader.</param>
+    /// <returns>The parsed ALTER TABLE query.</returns>
+    public static UpdateQuery Parse(ITokenReader r)
+    {
+        var uq = new UpdateQuery();
+
+        // with
+        if (r.Peek().IsEqualNoCase("with"))
+        {
+            uq.WithClause = WithClauseParser.Parse(r);
+        }
+
+        // update
+        uq.UpdateClause = UpdateClauseParser.Parse(r);
+
+        // set
+        uq.SetClause = SetClauseParser.Parse(r);
+
+        if (r.Peek().IsEqualNoCase("from"))
+        {
+            uq.FromClause = FromClauseParser.Parse(r);
+        }
+
+        if (r.Peek().IsEqualNoCase("where"))
+        {
+            uq.WhereClause = WhereClauseParser.Parse(r);
+        }
+
+        if (r.Peek().IsEqualNoCase("returning"))
+        {
+            uq.ReturningClause = ReturningClauseParser.Parse(r);
+        }
+
+        return uq;
+    }
+}

--- a/test/Carbunql.Analysis.Test/UpdateQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/UpdateQueryParserTest.cs
@@ -1,0 +1,290 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.Analysis.Test;
+
+public class UpdateQueryParserTest
+{
+    private readonly QueryCommandMonitor Monitor;
+
+    public UpdateQueryParserTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
+
+    [Fact]
+    public void QueryCommandableParserTest()
+    {
+        var text = @"UPDATE table_a SET value = 1";
+        var q = QueryCommandableParser.Parse(text);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void QueryCommandableParserTest_Cte()
+    {
+        var text = @"
+        WITH cte AS (
+            SELECT id, value FROM table_b WHERE value > 10
+        )
+        UPDATE table_a
+        SET value = cte.value
+        FROM cte
+        WHERE table_a.id = cte.id";
+        var q = QueryCommandableParser.Parse(text);
+
+        var actual = q.ToText();
+        var expect = """
+            WITH
+                cte AS (
+                    SELECT
+                        id,
+                        value
+                    FROM
+                        table_b
+                    WHERE
+                        value > 10
+                )
+            UPDATE
+                table_a
+            SET
+                value = cte.value
+            FROM
+                cte
+            WHERE
+                table_a.id = cte.id
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateAllTest()
+    {
+        var text = @"UPDATE table_a SET value = 1";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithWhereTest()
+    {
+        var text = @"UPDATE table_a SET value = 1 WHERE id = 10";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1
+            WHERE
+                id = 10
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateMultipleColumnsTest()
+    {
+        var text = @"UPDATE table_a SET value = 1, name = 'John'";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1,
+                name = 'John'
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithSubqueryTest()
+    {
+        var text = @"UPDATE table_a SET value = (SELECT max(value) FROM table_b)";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = (
+                    SELECT
+                        MAX(value)
+                    FROM
+                        table_b
+                )
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithJoinTest()
+    {
+        var text = @"UPDATE table_a SET value = 1 FROM table_b WHERE table_a.id = table_b.id";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1
+            FROM
+                table_b
+            WHERE
+                table_a.id = table_b.id
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithReturningTest()
+    {
+        var text = @"UPDATE table_a SET value = 1 WHERE id = 10 RETURNING id, value";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            UPDATE
+                table_a
+            SET
+                value = 1
+            WHERE
+                id = 10
+            RETURNING
+                id, value
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithTableAliasTest()
+    {
+        var text = @"UPDATE table_a AS a SET value = 1 WHERE a.id = 10";
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        UPDATE
+            table_a AS a
+        SET
+            value = 1
+        WHERE
+            a.id = 10
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithCteTest()
+    {
+        var text = @"
+        WITH cte AS (
+            SELECT id, value FROM table_b WHERE value > 10
+        )
+        UPDATE table_a
+        SET value = cte.value
+        FROM cte
+        WHERE table_a.id = cte.id";
+
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        WITH
+            cte AS (
+                SELECT
+                    id,
+                    value
+                FROM
+                    table_b
+                WHERE
+                    value > 10
+            )
+        UPDATE
+            table_a
+        SET
+            value = cte.value
+        FROM
+            cte
+        WHERE
+            table_a.id = cte.id
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void UpdateWithInnerJoinTest()
+    {
+        var text = @"
+        UPDATE table_a a
+        SET value = table_b.value
+        FROM table_b b
+        INNER JOIN table_c c ON b.id = c.b_id
+        WHERE a.id = b.id";
+
+        var q = UpdateQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        UPDATE
+            table_a AS a
+        SET
+            value = table_b.value
+        FROM
+            table_b AS b
+            INNER JOIN table_c AS c ON b.id = c.b_id
+        WHERE
+            a.id = b.id
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+}


### PR DESCRIPTION
- Implemented parsing for basic UPDATE statements.
- Added support for parsing complex UPDATE queries with WHERE, FROM, and JOIN clauses.
- Added support for parsing CTEs (Common Table Expressions) in UPDATE queries.
- Added unit tests.