### PR TITLE
Add support for parsing DELETE queries

### DIFF
--- a/demo/CarbunqlWeb/Pages/Format.razor
+++ b/demo/CarbunqlWeb/Pages/Format.razor
@@ -8,7 +8,7 @@
 
 <RadzenText TextStyle="TextStyle.H4">Format</RadzenText>
 
-<RadzenText>SQL can be formatted.(select, values, insert, update, create table, create index, alter table)</RadzenText>
+<RadzenText>SQL can be formatted.(select, values, insert, update, delete, create table, create index, alter table)</RadzenText>
 
 <RadzenTabs TabPosition=TabPosition.Top RenderMode="TabRenderMode.Client" >
     <Tabs>

--- a/src/Carbunql/Analysis/DeleteQueryParser.cs
+++ b/src/Carbunql/Analysis/DeleteQueryParser.cs
@@ -1,11 +1,14 @@
 ﻿using Carbunql.Analysis.Parser;
+using Carbunql.Clauses;
 using Carbunql.Extensions;
 
 namespace Carbunql.Analysis;
 
-public static class UpdateQueryParser
+
+public static class DeleteQueryParser
 {
-    public static UpdateQuery Parse(string text)
+
+    public static DeleteQuery Parse(string text)
     {
         var r = new SqlTokenReader(text);
         var query = Parse(r);
@@ -19,37 +22,29 @@ public static class UpdateQueryParser
         return query;
     }
 
-    public static UpdateQuery Parse(ITokenReader r)
+    public static DeleteQuery Parse(ITokenReader r)
     {
-        var uq = new UpdateQuery();
+        var dq = new DeleteQuery();
 
         // with
         if (r.Peek().IsEqualNoCase("with"))
         {
-            uq.WithClause = WithClauseParser.Parse(r);
+            dq.WithClause = WithClauseParser.Parse(r);
         }
 
         // update
-        uq.UpdateClause = UpdateClauseParser.Parse(r);
-
-        // set
-        uq.SetClause = SetClauseParser.Parse(r);
-
-        if (r.Peek().IsEqualNoCase("from"))
-        {
-            uq.FromClause = FromClauseParser.Parse(r);
-        }
+        dq.DeleteClause = DeleteClauseParser.Parse(r);
 
         if (r.Peek().IsEqualNoCase("where"))
         {
-            uq.WhereClause = WhereClauseParser.Parse(r);
+            dq.WhereClause = WhereClauseParser.Parse(r);
         }
 
         if (r.Peek().IsEqualNoCase("returning"))
         {
-            uq.ReturningClause = ReturningClauseParser.Parse(r);
+            dq.ReturningClause = ReturningClauseParser.Parse(r);
         }
 
-        return uq;
+        return dq;
     }
 }

--- a/src/Carbunql/Analysis/DeleteQueryParser.cs
+++ b/src/Carbunql/Analysis/DeleteQueryParser.cs
@@ -26,14 +26,17 @@ public static class DeleteQueryParser
     {
         var dq = new DeleteQuery();
 
-        // with
         if (r.Peek().IsEqualNoCase("with"))
         {
             dq.WithClause = WithClauseParser.Parse(r);
         }
 
-        // update
         dq.DeleteClause = DeleteClauseParser.Parse(r);
+
+        if (r.Peek().IsEqualNoCase("using"))
+        {
+            dq.UsingClause = DeleteUsingClauseParser.Parse(r);
+        }
 
         if (r.Peek().IsEqualNoCase("where"))
         {

--- a/src/Carbunql/Analysis/Parser/DeleteClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/DeleteClauseParser.cs
@@ -1,0 +1,20 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class DeleteClauseParser
+{
+
+    public static DeleteClause Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        return Parse(r);
+    }
+
+    public static DeleteClause Parse(ITokenReader r)
+    {
+        r.Read("delete");
+        r.Read("from");
+        return new DeleteClause(SelectableTableParser.Parse(r));
+    }
+}

--- a/src/Carbunql/Analysis/Parser/DeleteUsingClauseParser.cs
+++ b/src/Carbunql/Analysis/Parser/DeleteUsingClauseParser.cs
@@ -1,0 +1,31 @@
+﻿using Carbunql.Clauses;
+
+namespace Carbunql.Analysis.Parser;
+
+public static class DeleteUsingClauseParser
+{
+
+    public static DeleteUsingClause Parse(string text)
+    {
+        var r = new SqlTokenReader(text);
+        return Parse(r);
+    }
+
+    public static DeleteUsingClause Parse(ITokenReader r)
+    {
+        r.Read("using");
+
+        var u = new DeleteUsingClause()
+        {
+            SelectableTableParser.Parse(r)
+        };
+
+        while (r.Peek() == ",")
+        {
+            r.Read(",");
+            u.Add(SelectableTableParser.Parse(r));
+        }
+
+        return u;
+    }
+}

--- a/src/Carbunql/Analysis/Parser/SelectableTableParser.cs
+++ b/src/Carbunql/Analysis/Parser/SelectableTableParser.cs
@@ -47,7 +47,7 @@ public static class SelectableTableParser
             r.ReadOrDefault("as");
 
             var next = r.Peek();
-            if (next.IsEqualNoCase(["from", "set"]))
+            if (next.IsEqualNoCase(["from", "set", "using"]))
             {
                 return new SelectableTable(v, v.GetDefaultName());
             }

--- a/src/Carbunql/Analysis/QueryCommandableParser.cs
+++ b/src/Carbunql/Analysis/QueryCommandableParser.cs
@@ -70,6 +70,12 @@ public static class QueryCommandableParser
                 uq.WithClause = clause;
                 return uq;
             }
+            else if (token.IsEqualNoCase("delete"))
+            {
+                var dq = DeleteQueryParser.Parse(r);
+                dq.WithClause = clause;
+                return dq;
+            }
 
             throw new NotSupportedException($"Unsupported query command: '{token}'");
         }
@@ -80,6 +86,7 @@ public static class QueryCommandableParser
 
             if (token.IsEqualNoCase("insert into")) return InsertQueryParser.Parse(r);
             if (token.IsEqualNoCase("update")) return UpdateQueryParser.Parse(r);
+            if (token.IsEqualNoCase("delete")) return DeleteQueryParser.Parse(r);
 
             if (token.IsEqualNoCase("create table")) return CreateTableQueryParser.Parse(r);
             if (token.IsEqualNoCase("create index")) return CreateIndexQueryParser.Parse(r);

--- a/src/Carbunql/Clauses/DeleteUsingClause.cs
+++ b/src/Carbunql/Clauses/DeleteUsingClause.cs
@@ -1,0 +1,71 @@
+﻿using Carbunql.Tables;
+using Carbunql.Values;
+
+namespace Carbunql.Clauses;
+
+/// <summary>
+/// Represents a USING statement in SQL.
+/// </summary>
+public class DeleteUsingClause : QueryCommandCollection<SelectableTable>, IQueryCommandable
+{
+    public IEnumerable<ColumnValue> GetColumns()
+    {
+        foreach (var x in Items)
+        {
+            foreach (var item in x.GetColumns())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<CommonTable> GetCommonTables()
+    {
+        foreach (var x in Items)
+        {
+            foreach (var item in x.GetCommonTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<SelectQuery> GetInternalQueries()
+    {
+        foreach (var x in Items)
+        {
+            foreach (var item in x.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<PhysicalTable> GetPhysicalTables()
+    {
+        foreach (var x in Items)
+        {
+            foreach (var item in x.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public override IEnumerable<Token> GetTokens(Token? parent)
+    {
+        Token clause = GetClauseToken(parent);
+        yield return clause;
+
+        foreach (var item in base.GetTokens(clause)) yield return item;
+    }
+
+    private Token GetClauseToken(Token? parent)
+    {
+        return Token.Reserved(this, parent, "using");
+    }
+}

--- a/src/Carbunql/DeleteQuery.cs
+++ b/src/Carbunql/DeleteQuery.cs
@@ -20,6 +20,11 @@ public class DeleteQuery : IQueryCommandable, IReturning, ICommentable
     public WithClause? WithClause { get; set; }
 
     /// <summary>
+    /// Gets or sets the using clause.
+    /// </summary>
+    public DeleteUsingClause? UsingClause { get; set; }
+
+    /// <summary>
     /// Gets or sets the where clause.
     /// </summary>
     public WhereClause? WhereClause { get; set; }
@@ -59,6 +64,13 @@ public class DeleteQuery : IQueryCommandable, IReturning, ICommentable
                 yield return item;
             }
         }
+        if (UsingClause != null)
+        {
+            foreach (var item in UsingClause.GetInternalQueries())
+            {
+                yield return item;
+            }
+        }
         if (WhereClause != null)
         {
             foreach (var item in WhereClause.GetInternalQueries())
@@ -91,6 +103,13 @@ public class DeleteQuery : IQueryCommandable, IReturning, ICommentable
         if (WithClause != null)
         {
             foreach (var item in WithClause.GetPhysicalTables())
+            {
+                yield return item;
+            }
+        }
+        if (UsingClause != null)
+        {
+            foreach (var item in UsingClause.GetPhysicalTables())
             {
                 yield return item;
             }
@@ -139,6 +158,7 @@ public class DeleteQuery : IQueryCommandable, IReturning, ICommentable
 
         if (WithClause != null) foreach (var item in WithClause.GetTokens(parent)) yield return item;
         foreach (var item in DeleteClause.GetTokens(parent)) yield return item;
+        if (UsingClause != null) foreach (var item in UsingClause.GetTokens(parent)) yield return item;
         if (WhereClause != null) foreach (var item in WhereClause.GetTokens(parent)) yield return item;
 
         if (ReturningClause == null) yield break;

--- a/test/Carbunql.Analysis.Test/DeleteQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/DeleteQueryParserTest.cs
@@ -1,0 +1,164 @@
+﻿using Xunit.Abstractions;
+
+namespace Carbunql.Analysis.Test;
+
+public class DeleteQueryParserTest
+{
+    private readonly QueryCommandMonitor Monitor;
+
+    public DeleteQueryParserTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
+
+    [Fact]
+    public void QueryCommandableParserTest()
+    {
+        var text = @"DELETE FROM table_a WHERE id = 1";
+        var q = QueryCommandableParser.Parse(text);
+
+        var actual = q.ToText();
+        var expect = """
+            DELETE FROM
+                table_a
+            WHERE
+                id = 1
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void QueryCommandableParserTest_Cte()
+    {
+        var text = @"
+        WITH cte AS (
+            SELECT id FROM table_b WHERE status = 'inactive'
+        )
+        DELETE FROM table_a
+        WHERE table_a.id IN (SELECT id FROM cte)";
+        var q = QueryCommandableParser.Parse(text);
+
+        var actual = q.ToText();
+        var expect = """
+            WITH
+                cte AS (
+                    SELECT
+                        id
+                    FROM
+                        table_b
+                    WHERE
+                        status = 'inactive'
+                )
+            DELETE FROM
+                table_a
+            WHERE
+                table_a.id IN (
+                    SELECT
+                        id
+                    FROM
+                        cte
+                )
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+    [Fact]
+    public void DeleteBasicTest()
+    {
+        var text = @"DELETE FROM table_a WHERE id = 1";
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        DELETE FROM
+            table_a
+        WHERE
+            id = 1
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void DeleteWithAliasTest()
+    {
+        var text = @"DELETE FROM table_a AS a WHERE a.id = 1";
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        DELETE FROM
+            table_a AS a
+        WHERE
+            a.id = 1
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void DeleteWithReturningColumnsTest()
+    {
+        var text = @"DELETE FROM table_a WHERE id = 1 RETURNING id, value";
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        DELETE FROM
+            table_a
+        WHERE
+            id = 1
+        RETURNING
+            id, value
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void DeleteWithCteTest()
+    {
+        var text = @"
+        WITH cte AS (
+            SELECT id FROM table_b WHERE status = 'inactive'
+        )
+        DELETE FROM table_a
+        WHERE table_a.id IN (SELECT id FROM cte)";
+
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        WITH
+            cte AS (
+                SELECT
+                    id
+                FROM
+                    table_b
+                WHERE
+                    status = 'inactive'
+            )
+        DELETE FROM
+            table_a
+        WHERE
+            table_a.id IN (
+                SELECT
+                    id
+                FROM
+                    cte
+            )
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+}

--- a/test/Carbunql.Analysis.Test/DeleteQueryParserTest.cs
+++ b/test/Carbunql.Analysis.Test/DeleteQueryParserTest.cs
@@ -102,6 +102,62 @@ public class DeleteQueryParserTest
     }
 
     [Fact]
+    public void DeleteWithUsingTest()
+    {
+        var text = @"
+        DELETE FROM table_a as a
+        USING table_b as b
+        WHERE a.id = b.id
+        AND b.status = 'inactive'";
+
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+        DELETE FROM
+            table_a AS a
+        USING
+            table_b AS b
+        WHERE
+            a.id = b.id
+            AND b.status = 'inactive'
+        """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
+    public void DeleteWithMultipleTablesTest()
+    {
+        var text = @"
+            DELETE FROM orders AS o
+            USING customers AS c, payments AS p
+            WHERE o.customer_id = c.id
+              AND c.payment_id = p.id
+              AND p.status = 'completed';
+        ";
+        var q = DeleteQueryParser.Parse(text);
+
+        Monitor.Log(q);
+
+        var actual = q.ToText();
+        var expect = """
+            DELETE FROM
+                orders AS o
+            USING
+                customers AS c, payments AS p
+            WHERE
+                o.customer_id = c.id
+                AND c.payment_id = p.id
+                AND p.status = 'completed'
+            """;
+
+        Assert.Equal(expect, actual);
+    }
+
+    [Fact]
     public void DeleteWithReturningColumnsTest()
     {
         var text = @"DELETE FROM table_a WHERE id = 1 RETURNING id, value";


### PR DESCRIPTION
- Implemented parsing for basic DELETE statements.
- Added support for parsing CTEs (Common Table Expressions) in UPDATE queries.
- Added support for parsing USING clause in DELETE queries, including multiple tables and table aliases.
- Added unit tests.