### PR TITLE
Handle Extract function units (e.g., YEAR, MONTH) as reserved keywords.

### DIFF
--- a/src/Carbunql/Analysis/Parser/FromArgumentParser.cs
+++ b/src/Carbunql/Analysis/Parser/FromArgumentParser.cs
@@ -14,7 +14,7 @@ public static class FromArgumentParser
     /// <param name="unit">The unit value.</param>
     /// <param name="argument">The SQL text containing the FROM argument.</param>
     /// <returns>The parsed FROM argument.</returns>
-    public static FromArgument Parse(ValueBase unit, string argument)
+    public static FromArgument Parse(string unit, string argument)
     {
         var r = new SqlTokenReader(argument);
         return Parse(unit, r);
@@ -26,7 +26,7 @@ public static class FromArgumentParser
     /// <param name="unit">The unit value.</param>
     /// <param name="r">The token reader.</param>
     /// <returns>The parsed FROM argument.</returns>
-    public static FromArgument Parse(ValueBase unit, ITokenReader r)
+    public static FromArgument Parse(string unit, ITokenReader r)
     {
         var value = ValueParser.Parse(r);
         return new FromArgument(unit, value);

--- a/src/Carbunql/Analysis/Parser/ValueCollectionParser.cs
+++ b/src/Carbunql/Analysis/Parser/ValueCollectionParser.cs
@@ -58,7 +58,7 @@ public static class ValueCollectionParser
 
             if (r.ReadOrDefault("from") != null)
             {
-                yield return FromArgumentParser.Parse(v, r);
+                yield return FromArgumentParser.Parse(v.ToText(), r);
             }
             else if (r.ReadOrDefault("as") != null)
             {

--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql is an advanced Raw SQL editing library.</Description>
-		<Version>0.8.13</Version>
+		<Version>0.8.13.1</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/Values/FromArgument.cs
+++ b/src/Carbunql/Values/FromArgument.cs
@@ -22,7 +22,7 @@ public class FromArgument : ValueBase
     /// </summary>
     /// <param name="unit">The unit value.</param>
     /// <param name="value">The value.</param>
-    public FromArgument(ValueBase unit, ValueBase value)
+    public FromArgument(string unit, ValueBase value)
     {
         Unit = unit;
         Value = value;
@@ -31,7 +31,7 @@ public class FromArgument : ValueBase
     /// <summary>
     /// Gets or sets the unit value.
     /// </summary>
-    public ValueBase Unit { get; init; }
+    public string Unit { get; init; }
 
     /// <summary>
     /// Gets or sets the value.
@@ -41,10 +41,6 @@ public class FromArgument : ValueBase
     /// <inheritdoc/>
     protected override IEnumerable<SelectQuery> GetInternalQueriesCore()
     {
-        foreach (var item in Unit.GetInternalQueries())
-        {
-            yield return item;
-        }
         foreach (var item in Value.GetInternalQueries())
         {
             yield return item;
@@ -54,7 +50,9 @@ public class FromArgument : ValueBase
     /// <inheritdoc/>
     public override IEnumerable<Token> GetCurrentTokens(Token? parent)
     {
-        foreach (var item in Unit.GetTokens(parent)) yield return item;
+        if (string.IsNullOrEmpty(Unit)) throw new InvalidProgramException();
+
+        yield return Token.Reserved(this, parent, Unit);
         yield return Token.Reserved(this, parent, "from");
         foreach (var item in Value.GetTokens(parent)) yield return item;
     }
@@ -62,10 +60,6 @@ public class FromArgument : ValueBase
     /// <inheritdoc/>
     protected override IEnumerable<QueryParameter> GetParametersCore()
     {
-        foreach (var item in Unit.GetParameters())
-        {
-            yield return item;
-        }
         foreach (var item in Value.GetParameters())
         {
             yield return item;
@@ -75,10 +69,6 @@ public class FromArgument : ValueBase
     /// <inheritdoc/>
     protected override IEnumerable<PhysicalTable> GetPhysicalTablesCore()
     {
-        foreach (var item in Unit.GetPhysicalTables())
-        {
-            yield return item;
-        }
         foreach (var item in Value.GetPhysicalTables())
         {
             yield return item;
@@ -88,10 +78,6 @@ public class FromArgument : ValueBase
     /// <inheritdoc/>
     protected override IEnumerable<CommonTable> GetCommonTablesCore()
     {
-        foreach (var item in Unit.GetCommonTables())
-        {
-            yield return item;
-        }
         foreach (var item in Value.GetCommonTables())
         {
             yield return item;
@@ -100,10 +86,6 @@ public class FromArgument : ValueBase
 
     internal override IEnumerable<ColumnValue> GetColumnsCore()
     {
-        foreach (var item in Unit.GetColumns())
-        {
-            yield return item;
-        }
         foreach (var item in Value.GetColumns())
         {
             yield return item;
@@ -113,11 +95,6 @@ public class FromArgument : ValueBase
     public override IEnumerable<ValueBase> GetValues()
     {
         yield return this;
-
-        foreach (var item in Unit.GetValues())
-        {
-            yield return item;
-        }
 
         foreach (var item in Value.GetValues())
         {

--- a/test/Carbunql.Fluent.Test/FluentWhereTest.cs
+++ b/test/Carbunql.Fluent.Test/FluentWhereTest.cs
@@ -1,0 +1,80 @@
+using Xunit.Abstractions;
+
+namespace Carbunql.Fluent.Test;
+
+public class FluentWhereTest
+{
+    private readonly QueryCommandMonitor Monitor;
+
+    public FluentWhereTest(ITestOutputHelper output)
+    {
+        Monitor = new QueryCommandMonitor(output);
+    }
+
+    [Fact]
+    public void EqualTest()
+    {
+        var sq = new SelectQuery("""
+            select
+                a.id
+                , a.value
+            from
+                table_a a
+            """)
+            .Equal("id", 1);
+        ;
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                a.id,
+                a.value
+            FROM
+                table_a AS a
+            WHERE
+                a.id = 1
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void EqualTest_ExtractYear()
+    {
+        var sq = new SelectQuery("""
+            SELECT 
+                o.order_id,
+                c.customer_name,
+                o.order_date,
+                EXTRACT(YEAR FROM o.order_date) AS order_year,
+                EXTRACT(MONTH FROM o.order_date) AS order_month,
+                o.amount
+            FROM 
+                orders o
+            JOIN 
+                customers c ON o.customer_id = c.customer_id
+            """)
+            .Equal("order_year", 1);
+        ;
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                o.order_id,
+                c.customer_name,
+                o.order_date,
+                EXTRACT(YEAR FROM o.order_date) AS order_year,
+                EXTRACT(MONTH FROM o.order_date) AS order_month,
+                o.amount
+            FROM
+                orders AS o
+                JOIN customers AS c ON o.customer_id = c.customer_id
+            WHERE
+                EXTRACT(YEAR FROM o.order_date) = 1
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+}


### PR DESCRIPTION
Modified the parser to treat units within the EXTRACT function, such as YEAR and MONTH, as reserved keywords instead of column names, preventing parsing errors when these units are encountered in queries.