### PR TITLE
Enhance FluentTable with Improved Single Table Support

### DIFF
--- a/src/Carbunql/Clauses/SelectableTable.cs
+++ b/src/Carbunql/Clauses/SelectableTable.cs
@@ -53,6 +53,8 @@ public class SelectableTable : IQueryCommandable, ISelectable, ICommentable
     /// </summary>
     public ValueCollection? ColumnAliases { get; init; }
 
+    public bool HideColumnAliases { get; internal set; } = false;
+
     public CommentClause? CommentClause { get; set; }
 
     public IEnumerable<Token> GetAliasTokens(Token? parent)
@@ -90,7 +92,7 @@ public class SelectableTable : IQueryCommandable, ISelectable, ICommentable
             yield return new Token(this, parent, Alias);
         }
 
-        if (ColumnAliases != null)
+        if (ColumnAliases != null && HideColumnAliases == false)
         {
             var bracket = Token.ReservedBracketStart(this, parent);
             yield return bracket;

--- a/src/Carbunql/SelectQuery.cs
+++ b/src/Carbunql/SelectQuery.cs
@@ -138,7 +138,7 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
     {
         var commonTables = GetCommonTables().ToList();
         var sources = new List<IQuerySource>();
-        var lst = CreateQuerySources(ref sources, commonTables, new Numbering(0));
+        CreateQuerySources(ref sources, commonTables, new Numbering(0));
 
         return sources;
     }
@@ -169,6 +169,13 @@ public class SelectQuery : ReadQuery, IQueryCommandable, ICommentable
             {
                 var qs = DisassembleQuerySources(ref sources, source, query, commonTables, numbering, SourceType.SubQuery);
                 currentSources.Add(qs);
+            }
+            else if (source.ColumnAliases != null && source.ColumnAliases.Any())
+            {
+                // If a column alias is present, no further parsing is done
+                var names = source.ColumnAliases.SelectMany(x => x.GetColumns()).Select(x => x.Column).ToHashSet();
+                var qs = new QuerySource(numbering.GetNext(), names, this, source, SourceType.PhysicalTable);
+                sources.Add(qs);
             }
             else if (source.Table is PhysicalTable table && commonTables.Any(x => x.Alias == table.GetTableFullName()))
             {

--- a/src/Carbunql/Tables/VirtualTable.cs
+++ b/src/Carbunql/Tables/VirtualTable.cs
@@ -61,7 +61,17 @@ public class VirtualTable : TableBase
     /// <inheritdoc/>
     public override IList<string> GetColumnNames()
     {
-        if (Query is IReadQuery q)
+        if (Query is SelectQuery sq)
+        {
+            var s = sq.GetOrNewSelectQuery().SelectClause;
+            if (s == null)
+            {
+                var source = sq.GetQuerySources().Where(x => x.Query.Equals(sq)).First();
+                return source.ColumnNames.ToList();
+            }
+            return s.Select(x => x.Alias).ToList();
+        }
+        else if (Query is IReadQuery q)
         {
             var s = q.GetOrNewSelectQuery().SelectClause;
             if (s == null) return base.GetColumnNames();

--- a/test/Carbunql.Building.Test/ToCTETest.cs
+++ b/test/Carbunql.Building.Test/ToCTETest.cs
@@ -28,6 +28,29 @@ public class ToCTETest
 
         Monitor.Log(sq);
 
+        var expect = """
+            WITH
+                x AS (
+                    SELECT
+                        id,
+                        val
+                    FROM
+                        table_a AS a
+                ),
+                alias AS (
+                    SELECT
+                        x.id
+                    FROM
+                        x
+                )
+            SELECT
+                alias.id
+            FROM
+                alias
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+
         Assert.Equal(30, sq.GetTokens().ToList().Count);
     }
 
@@ -41,6 +64,29 @@ public class ToCTETest
         sq.Select(f);
 
         Monitor.Log(sq);
+
+        var expect = """
+            WITH
+                x AS (
+                    SELECT
+                        id,
+                        val
+                    FROM
+                        table_a AS a
+                ),
+                alias AS (
+                    SELECT
+                        x.id
+                    FROM
+                        x
+                )
+            SELECT
+                alias.id
+            FROM
+                alias
+            """;
+
+        Assert.Equal(expect, sq.ToText());
 
         Assert.Equal(30, sq.GetTokens().ToList().Count);
     }

--- a/test/Carbunql.Fluent.Test/FluentTableTest.cs
+++ b/test/Carbunql.Fluent.Test/FluentTableTest.cs
@@ -164,4 +164,108 @@ public class FluentTableTest
 
         Assert.Equal(expect, sq.ToText());
     }
+
+    [Fact]
+    public void SingleTableTest()
+    {
+        var a = FluentTable.Create("table_a", ["id", "value"], "a");
+
+        var sq = new SelectQuery()
+            .From(a)
+            .SelectAll(a);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                a.id,
+                a.value
+            FROM
+                table_a AS a
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void SingleTableCteTest_SelectAll()
+    {
+        var a = FluentTable.Create("table_a", ["id", "value"], "cte_a", "a");
+
+        var sq = new SelectQuery()
+            .From(a)
+            .SelectAll(a);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            WITH
+                cte_a AS (
+                    SELECT
+                        *
+                    FROM
+                        table_a
+                )
+            SELECT
+                a.id,
+                a.value
+            FROM
+                cte_a AS a
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void SingleTableCteFilterTest()
+    {
+        var a = FluentTable.Create("table_a", ["id", "value"], "cte_a", "a");
+
+        var sq = new SelectQuery()
+            .From(a)
+            .Equal("id", 1);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            WITH
+                cte_a AS (
+                    SELECT
+                        *
+                    FROM
+                        table_a
+                    WHERE
+                        table_a.id = 1
+                )
+            SELECT
+                *
+            FROM
+                cte_a AS a
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void SingleTableFilterTest()
+    {
+        var a = FluentTable.Create("table_a", ["id", "value"], "a");
+
+        var sq = new SelectQuery()
+            .From(a)
+            .Equal("id", 1);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                *
+            FROM
+                table_a AS a
+            WHERE
+                a.id = 1
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
 }


### PR DESCRIPTION
- Modified FluentTable to hide column aliases in SQL output when a single table is used.
- Column aliases are hidden only in the SQL output; column names are still recognized internally to support column filtering.