### PR TITLE
Added ExistsIn and NotExistsIn functions with improved argument order

### DIFF
--- a/src/Carbunql/Carbunql.csproj
+++ b/src/Carbunql/Carbunql.csproj
@@ -8,7 +8,7 @@
 		<Title></Title>
 		<Copyright>mk3008net</Copyright>
 		<Description>Carbunql is an advanced Raw SQL editing library.</Description>
-		<Version>0.8.13.2</Version>
+		<Version>0.8.14</Version>
 		<Authors>mk3008net</Authors>
 		<PackageProjectUrl>https://github.com/mk3008/Carbunql</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Carbunql/Fluent/SelectQueryWhereExtensions.cs
+++ b/src/Carbunql/Fluent/SelectQueryWhereExtensions.cs
@@ -522,7 +522,46 @@ public static class SelectQueryWhereExtensions
     /// <param name="keyColumnNames">A list of key column names used in the query.</param>
     /// <param name="validationTable">The FluentTable object used for validation.</param>
     /// <returns>Returns the updated SelectQuery object.</returns>
+    [Obsolete("use ExistsIn")]
     public static SelectQuery Exists(this SelectQuery query, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    {
+        return query.ExistsIn(validationTable, keyColumnNames);
+    }
+
+    /// <summary>
+    /// Applies an Exists query to the specified validation table based on the given table and key column names.
+    /// </summary>
+    /// <param name="query">The SelectQuery object to operate on.</param>
+    /// <param name="table">The FluentTable object to operate on.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <returns>Returns the updated SelectQuery object.</returns>
+    [Obsolete("use ExistsIn")]
+    public static SelectQuery Exists(this SelectQuery query, FluentTable table, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    {
+        return query.ExistsIn(validationTable, keyColumnNames, table);
+    }
+
+    [Obsolete("use ExistsIn")]
+    public static SelectQuery Exists(this SelectQuery query, IEnumerable<string> keyColumnNames, string validationTableName)
+    {
+        return query.ExistsIn(validationTableName, keyColumnNames);
+    }
+
+    [Obsolete("use ExistsIn")]
+    public static SelectQuery Exists(this SelectQuery query, string tableName, IEnumerable<string> keyColumnNames, string validationTableName)
+    {
+        return query.ExistsIn(validationTableName, keyColumnNames, tableName);
+    }
+
+    /// <summary>
+    /// Applies an Exists query to the specified validation table based on the key column names.
+    /// </summary>
+    /// <param name="query">The SelectQuery object to operate on.</param>
+    /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <returns>Returns the updated SelectQuery object.</returns>
+    public static SelectQuery ExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> keyColumnNames)
     {
         if (validationTable.IsCommonTable)
         {
@@ -546,15 +585,58 @@ public static class SelectQueryWhereExtensions
         return query;
     }
 
+    public static SelectQuery ExistsIn(this SelectQuery query, FluentTable validationTable, string condition)
+    {
+        if (validationTable.IsCommonTable)
+        {
+            query.With(validationTable);
+        }
+
+        query.Where(() =>
+        {
+            var sq = new SelectQuery().From(validationTable);
+            sq.Where(condition);
+            return sq.ToExists();
+        });
+
+        return query;
+    }
+
+    public static SelectQuery ExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> validationcolumns, FluentTable table, IEnumerable<string> columns)
+    {
+        if (columns.Count() != validationcolumns.Count())
+        {
+            throw new ArgumentException("The number of elements in columns and validationcolumns must be the same.");
+        }
+
+        var columnMaps = columns.Zip(validationcolumns, (left, right) => (left, right));
+
+        var lquery = new SelectQuery().From(table).GetCurrentQuerySource();
+        var rquery = new SelectQuery().From(validationTable).GetCurrentQuerySource();
+
+        var condition = string.Join(" and ", columnMaps.Select(item => $"{rquery.GetColumn(item.right, isAliasIncluded: true)} = {lquery.GetColumn(item.left, isAliasIncluded: true)}"));
+
+        var targetQuery = query.GetQuerySources()
+                    .Where(x => x.HasTable(table.Alias, true))
+                    .EnsureAny($"table:{table.Alias}")
+                    .GetRootsByQuery()
+                    .First()
+                    .Query;
+
+        targetQuery.ExistsIn(validationTable, condition);
+
+        return query;
+    }
+
     /// <summary>
     /// Applies an Exists query to the specified validation table based on the given table and key column names.
     /// </summary>
     /// <param name="query">The SelectQuery object to operate on.</param>
-    /// <param name="table">The FluentTable object to operate on.</param>
-    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
     /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <param name="table">The FluentTable object to operate on.</param>
     /// <returns>Returns the updated SelectQuery object.</returns>
-    public static SelectQuery Exists(this SelectQuery query, FluentTable table, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    public static SelectQuery ExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> keyColumnNames, FluentTable table)
     {
         if (validationTable.IsCommonTable)
         {
@@ -580,13 +662,13 @@ public static class SelectQueryWhereExtensions
         return query;
     }
 
-    public static SelectQuery Exists(this SelectQuery query, IEnumerable<string> keyColumnNames, string validationTableName)
+    public static SelectQuery ExistsIn(this SelectQuery query, string validationTableName, IEnumerable<string> keyColumnNames)
     {
         query.AddExists(keyColumnNames, validationTableName);
         return query;
     }
 
-    public static SelectQuery Exists(this SelectQuery query, string tableName, IEnumerable<string> keyColumnNames, string validationTableName)
+    public static SelectQuery ExistsIn(this SelectQuery query, string validationTableName, IEnumerable<string> keyColumnNames, string tableName)
     {
         query.AddExists(tableName, keyColumnNames, validationTableName);
         return query;
@@ -605,7 +687,89 @@ public static class SelectQueryWhereExtensions
     /// <param name="keyColumnNames">A list of key column names used in the query.</param>
     /// <param name="validationTable">The FluentTable object used for validation.</param>
     /// <returns>Returns the updated SelectQuery object.</returns>
+    [Obsolete("use NotExistsIn")]
     public static SelectQuery NotExists(this SelectQuery query, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    {
+        return query.NotExistsIn(validationTable, keyColumnNames);
+    }
+
+    /// <summary>
+    /// Applies a NotExists query to the specified validation table based on the given table and key column names.
+    /// </summary>
+    /// <param name="query">The SelectQuery object to operate on.</param>
+    /// <param name="table">The FluentTable object to operate on.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <returns>Returns the updated SelectQuery object.</returns>
+    [Obsolete("use NotExistsIn")]
+    public static SelectQuery NotExists(this SelectQuery query, FluentTable table, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    {
+        return query.NotExistsIn(validationTable, keyColumnNames, table);
+    }
+
+    [Obsolete("use NotExistsIn")]
+    public static SelectQuery NotExists(this SelectQuery query, IEnumerable<string> keyColumnNames, string validationTableName)
+    {
+        return query.NotExistsIn(validationTableName, keyColumnNames);
+    }
+
+    [Obsolete("use NotExistsIn")]
+    public static SelectQuery NotExists(this SelectQuery query, string tableName, IEnumerable<string> keyColumnNames, string validationTableName)
+    {
+        return query.NotExistsIn(validationTableName, keyColumnNames, tableName);
+    }
+
+    public static SelectQuery NotExistsIn(this SelectQuery query, FluentTable validationTable, string condition)
+    {
+        if (validationTable.IsCommonTable)
+        {
+            query.With(validationTable);
+        }
+
+        query.Where(() =>
+        {
+            var sq = new SelectQuery().From(validationTable);
+            sq.Where(condition);
+            return sq.ToNotExists();
+        });
+
+        return query;
+    }
+
+    public static SelectQuery NotExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> validationcolumns, FluentTable table, IEnumerable<string> columns)
+    {
+        if (columns.Count() != validationcolumns.Count())
+        {
+            throw new ArgumentException("The number of elements in columns and validationcolumns must be the same.");
+        }
+
+        var columnMaps = columns.Zip(validationcolumns, (left, right) => (left, right));
+
+        var lquery = new SelectQuery().From(table).GetCurrentQuerySource();
+        var rquery = new SelectQuery().From(validationTable).GetCurrentQuerySource();
+
+        var condition = string.Join(" and ", columnMaps.Select(item => $"{rquery.GetColumn(item.right, isAliasIncluded: true)} = {lquery.GetColumn(item.left, isAliasIncluded: true)}"));
+
+        var targetQuery = query.GetQuerySources()
+                    .Where(x => x.HasTable(table.Alias, true))
+                    .EnsureAny($"table:{table.Alias}")
+                    .GetRootsByQuery()
+                    .First()
+                    .Query;
+
+        targetQuery.NotExistsIn(validationTable, condition);
+
+        return query;
+    }
+
+    /// <summary>
+    /// Applies a NotExists query to the specified validation table based on the key column names.
+    /// </summary>
+    /// <param name="query">The SelectQuery object to operate on.</param>
+    /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <returns>Returns the updated SelectQuery object.</returns>
+    public static SelectQuery NotExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> keyColumnNames)
     {
         if (validationTable.IsCommonTable)
         {
@@ -633,11 +797,11 @@ public static class SelectQueryWhereExtensions
     /// Applies a NotExists query to the specified validation table based on the given table and key column names.
     /// </summary>
     /// <param name="query">The SelectQuery object to operate on.</param>
-    /// <param name="table">The FluentTable object to operate on.</param>
-    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
     /// <param name="validationTable">The FluentTable object used for validation.</param>
+    /// <param name="keyColumnNames">A list of key column names used in the query.</param>
+    /// <param name="table">The FluentTable object to operate on.</param>
     /// <returns>Returns the updated SelectQuery object.</returns>
-    public static SelectQuery NotExists(this SelectQuery query, FluentTable table, IEnumerable<string> keyColumnNames, FluentTable validationTable)
+    public static SelectQuery NotExistsIn(this SelectQuery query, FluentTable validationTable, IEnumerable<string> keyColumnNames, FluentTable table)
     {
         if (validationTable.IsCommonTable)
         {
@@ -663,13 +827,13 @@ public static class SelectQueryWhereExtensions
         return query;
     }
 
-    public static SelectQuery NotExists(this SelectQuery query, IEnumerable<string> keyColumnNames, string validationTableName)
+    public static SelectQuery NotExistsIn(this SelectQuery query, string validationTableName, IEnumerable<string> keyColumnNames)
     {
         query.AddNotExists(keyColumnNames, validationTableName);
         return query;
     }
 
-    public static SelectQuery NotExists(this SelectQuery query, string tableName, IEnumerable<string> keyColumnNames, string validationTableName)
+    public static SelectQuery NotExistsIn(this SelectQuery query, string validationTableName, IEnumerable<string> keyColumnNames, string tableName)
     {
         query.AddNotExists(tableName, keyColumnNames, validationTableName);
         return query;

--- a/test/Carbunql.Fluent.Test/Sample.cs
+++ b/test/Carbunql.Fluent.Test/Sample.cs
@@ -153,7 +153,7 @@ public class Sample
     }
 
     [Fact]
-    public void SingleTable_Join_Custome()
+    public void SingleTable_Join_Custom()
     {
         var tableA = FluentTable.Create("table_a", ["id", "value"], "a");
         var tableB = FluentTable.Create("table_b", ["id", "table_a_id", "value"], "b");
@@ -266,7 +266,7 @@ public class Sample
 
         var sq = new SelectQuery()
             .From(tableA)
-            .Exists(["table_a_id"], tableB);
+            .ExistsIn(tableB, ["table_a_id"]);
 
         Monitor.Log(sq);
 
@@ -297,7 +297,7 @@ public class Sample
 
         var sq = new SelectQuery()
             .From(tableA)
-            .Exists(tableA, ["table_a_id"], tableB);
+            .ExistsIn(tableB, ["table_a_id"], tableA);
 
         Monitor.Log(sq);
 
@@ -314,6 +314,68 @@ public class Sample
                         table_b AS b
                     WHERE
                         b.table_a_id = a.table_a_id
+                )
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void SingleTable_Exists_Custom()
+    {
+        var tableA = FluentTable.Create("table_a", ["id", "value"], "a");
+        var tableB = FluentTable.Create("table_b", ["table_a_id", "value"], "b");
+
+        var sq = new SelectQuery()
+            .From(tableA)
+            .ExistsIn(tableB, ["table_a_id"], tableA, ["id"]);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                *
+            FROM
+                table_a AS a
+            WHERE
+                EXISTS (
+                    SELECT
+                        *
+                    FROM
+                        table_b AS b
+                    WHERE
+                        b.table_a_id = a.id
+                )
+            """;
+
+        Assert.Equal(expect, sq.ToText());
+    }
+
+    [Fact]
+    public void SingleTable_NotExists_Custom()
+    {
+        var tableA = FluentTable.Create("table_a", ["id", "value"], "a");
+        var tableB = FluentTable.Create("table_b", ["table_a_id", "value"], "b");
+
+        var sq = new SelectQuery()
+            .From(tableA)
+            .NotExistsIn(tableB, ["table_a_id"], tableA, ["id"]);
+
+        Monitor.Log(sq);
+
+        var expect = """
+            SELECT
+                *
+            FROM
+                table_a AS a
+            WHERE
+                NOT EXISTS (
+                    SELECT
+                        *
+                    FROM
+                        table_b AS b
+                    WHERE
+                        b.table_a_id = a.id
                 )
             """;
 


### PR DESCRIPTION
Newly added ExistsIn and NotExistsIn functions have an argument order aligned with the Select and Join functions for consistency. The existing Exists and NotExists functions are retained as deprecated to maintain backward compatibility.