### PR TITLE
Demo site target framework and package version update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
    
       - name: Dotnet Publish
         run: dotnet publish $PROJECT_FOLDER/$PROJECT_FILE --configuration Release

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
     env:
      PROJECT_FILE: CarbunqlWeb.csproj
      PROJECT_FOLDER: demo/CarbunqlWeb
-     PUBLISH_FOLDER: demo/CarbunqlWeb/bin/Release/net7.0/publish/wwwroot
+     PUBLISH_FOLDER: demo/CarbunqlWeb/bin/Release/net8.0/publish/wwwroot
 
     name: Build and Deploy Job
     steps:

--- a/demo/CarbunqlWeb/CarbunqlWeb.csproj
+++ b/demo/CarbunqlWeb/CarbunqlWeb.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<RunAOTCompilation>False</RunAOTCompilation>
+		<!--<RunAOTCompilation>False</RunAOTCompilation>-->
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -13,9 +13,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="7.0.20" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.0" PrivateAssets="all" />
 		<PackageReference Include="Radzen.Blazor" Version="4.4.7" />
 		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0" />
 		<PackageReference Include="System.Text.Json" Version="9.0.0" />


### PR DESCRIPTION
The target framework of the demo site project has been changed from `net7.0` to `net8.0`.